### PR TITLE
10 extract api methods

### DIFF
--- a/javacore_analyzer.py
+++ b/javacore_analyzer.py
@@ -22,6 +22,7 @@ from javacore_set import JavacoreSet
 
 LOGGING_FORMAT = '%(asctime)s [%(levelname)s][%(filename)s:%(lineno)s] %(message)s'
 
+SUPPORTED_ARCHIVES_FORMATS = {"zip", "gz", "tgz", "bz2", "lzma", "7z"}
 
 def create_output_files_structure(output_dir):
     if not os.path.isdir(output_dir):
@@ -39,7 +40,6 @@ def create_file_logging(output_param):
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(logging.Formatter(LOGGING_FORMAT))
     logging.getLogger().addHandler(file_handler)
-
 
 def extract_archive(input_archive_filename, output_path):
     """
@@ -102,37 +102,44 @@ def main():
     output_param = args.output_param
     files_separator = args.separator
 
-    # Location when we store extracted archive or copied javacore files
-    javacores_temp_dir = tempfile.TemporaryDirectory()
-    javacores_temp_dir_name = javacores_temp_dir.name
+    logging.info("Input parameter: " + input_param)
+    logging.info("Report directory: " + output_param)
+
+    # Check whether as input we got list of files or single file
+    # Semicolon is separation mark for list of input files
+    if files_separator in input_param or fnmatch.fnmatch(input_param, '*javacore*.txt'):
+        # Process list of the files (copy all or them to output dir
+        files = input_param.split(files_separator)
+    else:
+        files = [input_param]
 
     try:
-        logging.info("Input parameter: " + input_param)
-        logging.info("Report directory: " + output_param)
+        # Location when we store extracted archive or copied javacore files
+        javacores_temp_dir = tempfile.TemporaryDirectory()
+        # It is strange but sometimes the temp directory contains the content from previous run
+        #javacores_temp_dir.cleanup()
+
+        javacores_temp_dir_name = javacores_temp_dir.name
 
         create_output_files_structure(output_param)
 
         # Needs to be created once output file structure is ready.
         create_file_logging(output_param)
 
-        # Check whether as input we got list of files or single file
-        # Colon is separation mark for list of input files
-        if files_separator in input_param or fnmatch.fnmatch(input_param, '*javacore*.txt'):
-            # Process list of the files (copy all or them to output dir
-            files = input_param.split(files_separator)
-            for file in files:
-                file = file.strip()
-                shutil.copy2(file, javacores_temp_dir_name)
-            path = javacores_temp_dir_name
-        elif os.path.isdir(input_param):
-            path = input_param # We do not want to copy the files to temp dir is an input is a dir
-        elif os.path.isfile(input_param):
-            path = extract_archive(input_param, javacores_temp_dir_name)  # Extract archive to temp dir
-        else:
-            logging.error(
-                "The specified parameter " + input_param + " is not a file or a directory. Cannot process it. Exiting")
-            exit(13)
-        JavacoreSet.process_javacores_dir(path, output_param)
+
+        for file in files:
+            #file = file.strip() # Remove leading or trailing space in file path
+            if os.path.isdir(file):
+                shutil.copytree(file, javacores_temp_dir_name, dirs_exist_ok=True)
+            else:
+                filename, extension = os.path.splitext(file)
+                extension = extension[1:] # trim trailing "."
+                if extension.lower() in SUPPORTED_ARCHIVES_FORMATS:
+                    extract_archive(input_param, javacores_temp_dir_name)  # Extract archive to temp dir
+                else:
+                    shutil.copy2(file, javacores_temp_dir_name)
+
+        JavacoreSet.process_javacores_dir(javacores_temp_dir_name, output_param)
     except Exception as ex:
         traceback.print_exc(file=sys.stdout)
         logging.error("Processing was not successful. Correct the problem and try again. Exiting with error 13",

--- a/javacore_analyzer.py
+++ b/javacore_analyzer.py
@@ -117,35 +117,34 @@ def main():
         files = [input_param]
 
     try:
-        # Location when we store extracted archive or copied javacore files
-        javacores_temp_dir = tempfile.TemporaryDirectory()
-        # It is strange but sometimes the temp directory contains the content from previous run
-        #javacores_temp_dir.cleanup()
-
-        javacores_temp_dir_name = javacores_temp_dir.name
-
-        create_output_files_structure(output_param)
-
-        for file in files:
-            #file = file.strip() # Remove leading or trailing space in file path
-            if os.path.isdir(file):
-                shutil.copytree(file, javacores_temp_dir_name, dirs_exist_ok=True)
-            else:
-                filename, extension = os.path.splitext(file)
-                extension = extension[1:] # trim trailing "."
-                if extension.lower() in SUPPORTED_ARCHIVES_FORMATS:
-                    extract_archive(input_param, javacores_temp_dir_name)  # Extract archive to temp dir
-                else:
-                    shutil.copy2(file, javacores_temp_dir_name)
-
-        JavacoreSet.process_javacores_dir(javacores_temp_dir_name, output_param)
+        generate_javecore_set_data(files, output_param)
     except Exception as ex:
         traceback.print_exc(file=sys.stdout)
         logging.error("Processing was not successful. Correct the problem and try again. Exiting with error 13",
                       exc_info=True)
         exit(13)
-    finally:
-        javacores_temp_dir.cleanup()
+
+
+def generate_javecore_set_data(files, output_dir):
+    # Location when we store extracted archive or copied javacore files
+    javacores_temp_dir = tempfile.TemporaryDirectory()
+    # It is strange but sometimes the temp directory contains the content from previous run
+    # javacores_temp_dir.cleanup()
+    javacores_temp_dir_name = javacores_temp_dir.name
+    create_output_files_structure(output_dir)
+    for file in files:
+        # file = file.strip() # Remove leading or trailing space in file path
+        if os.path.isdir(file):
+            shutil.copytree(file, javacores_temp_dir_name, dirs_exist_ok=True)
+        else:
+            filename, extension = os.path.splitext(file)
+            extension = extension[1:]  # trim trailing "."
+            if extension.lower() in SUPPORTED_ARCHIVES_FORMATS:
+                extract_archive(file, javacores_temp_dir_name)  # Extract archive to temp dir
+            else:
+                shutil.copy2(file, javacores_temp_dir_name)
+    JavacoreSet.process_javacores_dir(javacores_temp_dir_name, output_dir)
+    return javacores_temp_dir
 
 
 if __name__ == "__main__":

--- a/javacore_analyzer.py
+++ b/javacore_analyzer.py
@@ -14,6 +14,7 @@ import tarfile
 import tempfile
 import traceback
 import zipfile
+from pathlib import Path
 
 import py7zr
 
@@ -34,8 +35,9 @@ def create_output_files_structure(output_dir):
     shutil.copytree("data", data_dir, dirs_exist_ok=True)
 
 
-def create_file_logging(output_param):
-    logging_file = output_param + "/wait2-debug.log"
+def create_file_logging(logging_file_dir):
+    logging_file = logging_file_dir + "/wait2-debug.log"
+    Path(logging_file_dir).mkdir(parents=True, exist_ok=True) # Sometimes the folder of logging might not exist
     file_handler = logging.FileHandler(logging_file, mode='w')
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(logging.Formatter(LOGGING_FORMAT))

--- a/javacore_analyzer.py
+++ b/javacore_analyzer.py
@@ -105,6 +105,9 @@ def main():
     logging.info("Input parameter: " + input_param)
     logging.info("Report directory: " + output_param)
 
+    # Needs to be created once output file structure is ready.
+    create_file_logging(output_param)
+
     # Check whether as input we got list of files or single file
     # Semicolon is separation mark for list of input files
     if files_separator in input_param or fnmatch.fnmatch(input_param, '*javacore*.txt'):
@@ -122,10 +125,6 @@ def main():
         javacores_temp_dir_name = javacores_temp_dir.name
 
         create_output_files_structure(output_param)
-
-        # Needs to be created once output file structure is ready.
-        create_file_logging(output_param)
-
 
         for file in files:
             #file = file.strip() # Remove leading or trailing space in file path

--- a/javacore_set.py
+++ b/javacore_set.py
@@ -160,8 +160,7 @@ class JavacoreSet:
         jset = JavacoreSet(path)
         jset.populate_files_list()
         if len(jset.files) < 1:
-            print("No javacores found. You need at least one javacore. Exiting with error 13")
-            exit(13)
+            raise RuntimeError("No javacores found. You need at least one javacore. Exiting with error 13")
         first_javacore = jset.get_one_javacore()
         jset.parse_common_data(first_javacore)
         jset.parse_javacores()

--- a/javacore_set.py
+++ b/javacore_set.py
@@ -87,16 +87,6 @@ class JavacoreSet:
         jset.generate_tips()
         return jset
 
-        jset = JavacoreSet.create(input_path)
-        jset.print_java_settings()
-        jset.populate_snapshot_collections()
-        jset.sort_snapshots()
-        # jset.find_top_blockers()
-        jset.print_blockers()
-        jset.print_thread_states()
-        jset.generate_tips()
-        return jset
-
 
     # Assisted by WCA@IBM
     # Latest GenAI contribution: ibm/granite-8b-code-instruct

--- a/javacore_set.py
+++ b/javacore_set.py
@@ -103,7 +103,7 @@ class JavacoreSet:
                                            "data/xml/threads/thread",
                                            self.threads,
                                            "thread")
-        self.generate_htmls_from_xmls_xsls(temp_dir_name + "/report.xml",
+        self.generate_htmls_from_xmls_xsls(self.report_xml_file,
                                            temp_dir_name + "/threads",
                                            output_dir + "/threads", )
 
@@ -112,7 +112,7 @@ class JavacoreSet:
                                            "data/xml/javacores/javacore",
                                            self.javacores,
                                            "")
-        self.generate_htmls_from_xmls_xsls(temp_dir_name + "/report.xml",
+        self.generate_htmls_from_xmls_xsls(self.report_xml_file,
                                            temp_dir_name + "/javacores",
                                            output_dir + "/javacores", )
 

--- a/javacore_set.py
+++ b/javacore_set.py
@@ -65,7 +65,18 @@ class JavacoreSet:
         self.tips = []
         self.gc_parser = VerboseGcParser()
 
-    def process_javacores_dir(input_path, output_path):
+    # Assisted by WCA@IBM
+    # Latest GenAI contribution: ibm/granite-8b-code-instruct
+    def process_javacores(input_path):
+        """
+        Processes Java core data and generates tips based on the analysis.
+
+        Args:
+            input_path (str): The path to the directory containing the Javacore data.
+
+        Returns:
+            JavacoreSet: A JavacoreSet object containing the analysis results.
+        """
         jset = JavacoreSet.create(input_path)
         jset.print_java_settings()
         jset.populate_snapshot_collections()
@@ -74,8 +85,17 @@ class JavacoreSet:
         jset.print_blockers()
         jset.print_thread_states()
         jset.generate_tips()
-        output_dir = output_path
-        jset.generate_report_files(output_dir)
+        return jset
+
+        jset = JavacoreSet.create(input_path)
+        jset.print_java_settings()
+        jset.populate_snapshot_collections()
+        jset.sort_snapshots()
+        # jset.find_top_blockers()
+        jset.print_blockers()
+        jset.print_thread_states()
+        jset.generate_tips()
+        return jset
 
 
     # Assisted by WCA@IBM
@@ -93,10 +113,20 @@ class JavacoreSet:
         temp_dir = tempfile.TemporaryDirectory()
         temp_dir_name = temp_dir.name
         logging.info("Created temp dir: " + temp_dir_name)
+        self.__create_output_files_structure(output_dir)
         self.__create_report_xml(temp_dir_name + "/report.xml")
         self.__generate_htmls_for_threads(output_dir, temp_dir_name)
         self.__generate_htmls_for_javacores(output_dir, temp_dir_name)
         self.__create_index_html(temp_dir_name, output_dir)
+
+    def __create_output_files_structure(self, output_dir):
+        if not os.path.isdir(output_dir):
+            os.mkdir(output_dir)
+        data_dir = output_dir + '/data'
+        if os.path.isdir(data_dir):
+            shutil.rmtree(data_dir, ignore_errors=True)
+        logging.info("Data dir: " + data_dir)
+        shutil.copytree("data", data_dir, dirs_exist_ok=True)
 
     def __generate_htmls_for_threads(self, output_dir, temp_dir_name):
         self.create_xml_xsl_for_collection(temp_dir_name + "/threads",

--- a/javacore_set.py
+++ b/javacore_set.py
@@ -52,6 +52,7 @@ class JavacoreSet:
         self.verbose_gc_files = []
         self.threads = SnapshotCollectionCollection(Thread)
         self.stacks = SnapshotCollectionCollection(CodeSnapshotCollection)
+        self.report_xml_file = None
 
         self.doc = None
 
@@ -92,7 +93,7 @@ class JavacoreSet:
         temp_dir = tempfile.TemporaryDirectory()
         temp_dir_name = temp_dir.name
         logging.info("Created temp dir: " + temp_dir_name)
-        self.create_report_xml(temp_dir_name + "/report.xml")
+        self.__create_report_xml(temp_dir_name + "/report.xml")
         self.__generate_htmls_for_threads(output_dir, temp_dir_name)
         self.__generate_htmls_for_javacores(output_dir, temp_dir_name)
         self.__create_index_html(temp_dir_name, output_dir)
@@ -272,7 +273,7 @@ class JavacoreSet:
 
     # Assisted by WCA@IBM
     # Latest GenAI contribution: ibm/granite-8b-code-instruct
-    def create_report_xml(self, output_file):
+    def __create_report_xml(self, output_file):
         """
         Generate an XML report containing information about the Javacoreset data.
 
@@ -411,8 +412,26 @@ class JavacoreSet:
         self.doc.writexml(stream, indent="  ", addindent="  ", newl='\n', encoding="utf-8")
         stream.close()
         self.doc.unlink()
+        self.report_xml_file = output_file
 
         logging.info("Finished generating report xml")
+
+    # Assisted by WCA@IBM
+    # Latest GenAI contribution: ibm/granite-8b-code-instruct
+    def get_javacore_set_in_xml(self):
+        """
+        Returns the JavaCore set in the XML report file.
+
+        Parameters:
+        self (JavacoreSet): The instance of the javacore_set class.
+
+        Returns:
+        str: The JavaCore set in the XML format.
+        """
+        file = open(self.report_xml_file, "r")
+        content = file.read()
+        file.close()
+        return content
 
     @staticmethod
     def __create_index_html(input_dir, output_dir):

--- a/javacore_set.py
+++ b/javacore_set.py
@@ -65,27 +65,39 @@ class JavacoreSet:
         self.gc_parser = VerboseGcParser()
 
     def process_javacores_dir(input_path, output_path):
-        temp_dir = tempfile.TemporaryDirectory()
-        try:
-            jset = JavacoreSet.create(input_path)
-            jset.print_java_settings()
-            jset.populate_snapshot_collections()
-            jset.sort_snapshots()
-            # jset.find_top_blockers()
-            jset.print_blockers()
-            jset.print_thread_states()
-            jset.generate_tips()
-            output_dir = output_path
-            temp_dir_name = temp_dir.name
-            logging.info("Created temp dir: " + temp_dir_name)
-            jset.create_report_xml(temp_dir_name + "/report.xml")
-            jset.generate_htmls_for_threads(output_dir, temp_dir_name)
-            jset.generate_htmls_for_javacores(output_dir, temp_dir_name)
-            jset.create_index_html(temp_dir_name, output_dir)
-        finally:
-            temp_dir.cleanup()
+        jset = JavacoreSet.create(input_path)
+        jset.print_java_settings()
+        jset.populate_snapshot_collections()
+        jset.sort_snapshots()
+        # jset.find_top_blockers()
+        jset.print_blockers()
+        jset.print_thread_states()
+        jset.generate_tips()
+        output_dir = output_path
+        jset.generate_report_files(output_dir)
 
-    def generate_htmls_for_threads(self, output_dir, temp_dir_name):
+
+    # Assisted by WCA@IBM
+    # Latest GenAI contribution: ibm/granite-8b-code-instruct
+    def generate_report_files(self, output_dir):
+        """
+        Generate report files in HTML format.
+
+        Parameters:
+        - output_dir (str): The directory where the generated report files will be saved.
+
+        Returns:
+        - None
+        """
+        temp_dir = tempfile.TemporaryDirectory()
+        temp_dir_name = temp_dir.name
+        logging.info("Created temp dir: " + temp_dir_name)
+        self.create_report_xml(temp_dir_name + "/report.xml")
+        self.__generate_htmls_for_threads(output_dir, temp_dir_name)
+        self.__generate_htmls_for_javacores(output_dir, temp_dir_name)
+        self.__create_index_html(temp_dir_name, output_dir)
+
+    def __generate_htmls_for_threads(self, output_dir, temp_dir_name):
         self.create_xml_xsl_for_collection(temp_dir_name + "/threads",
                                            "data/xml/threads/thread",
                                            self.threads,
@@ -94,7 +106,7 @@ class JavacoreSet:
                                            temp_dir_name + "/threads",
                                            output_dir + "/threads", )
 
-    def generate_htmls_for_javacores(self, output_dir, temp_dir_name):
+    def __generate_htmls_for_javacores(self, output_dir, temp_dir_name):
         self.create_xml_xsl_for_collection(temp_dir_name + "/javacores",
                                            "data/xml/javacores/javacore",
                                            self.javacores,
@@ -258,8 +270,18 @@ class JavacoreSet:
             logging.debug(thread.name + "(id: " + str(thread.id) + "; hash: " + thread.get_hash() + ") " + \
             "states: " + thread.get_snapshot_states())
 
+    # Assisted by WCA@IBM
+    # Latest GenAI contribution: ibm/granite-8b-code-instruct
     def create_report_xml(self, output_file):
-        """ get all information an concatenate in an xml"""
+        """
+        Generate an XML report containing information about the Javacoreset data.
+
+        Parameters:
+        - output_file (str): The path and filename of the output XML file.
+
+        Returns:
+        None
+        """
 
         logging.info("Generating report xml")
 
@@ -393,7 +415,7 @@ class JavacoreSet:
         logging.info("Finished generating report xml")
 
     @staticmethod
-    def create_index_html(input_dir, output_dir):
+    def __create_index_html(input_dir, output_dir):
 
         # Copy index.xml and report.xsl to temp - for index.html we don't need to generate anything. Copying is enough.
         shutil.copy2("data/xml/index.xml", input_dir)

--- a/test/test_javacore_analyzer.py
+++ b/test/test_javacore_analyzer.py
@@ -54,12 +54,19 @@ class TestJavacoreAnalyzer(unittest.TestCase):
                                                                          "tmp")
         except CorruptedJavacoreException:
             test_failed = True
-        self.assertTrue(test_failed, "Program on corrupted file should fail but finished successfully")
+        self.assertTrue(test_failed, "API on corrupted file should fail but finished successfully")
         javacore_analyzer.process_javacores_and_generate_report_data(
             ["test/data/javacores/javacore.20220606.114458.32888.0001.txt",
              "test/data/javacores/javacore.20220606.114502.32888.0002.txt"], "tmp")
         javacore_analyzer.process_javacores_and_generate_report_data(
             ["test/data/javacores"], "tmp")
+
+        test_failed = False
+        try:
+            javacore_analyzer.process_javacores_and_generate_report_data([],"tmp")
+        except RuntimeError:
+            test_failed = True
+        self.assertTrue(test_failed, "API on missing javacores should fail but finished successfully")
 
     def test_issue129(self):
         self.runMainWithParams(self.issue129)


### PR DESCRIPTION
Ref #10 

I have created the following API methods:
```
javacore_analyzer.process_javacores_and_generate_report_data
javacore_analyzer.generate_javecore_set_data
javacore_set.JavacoreSet.generate_report_files
javacore_set.JavacoreSet.get_javacore_set_in_xml
```
Also `javacore_set.JavacoreSet` is public API class.

I expected the change to be smaller but it is at it is. 

All tests are passing

Please check if API methods have correct name and correct documentation.

Some of the methods/variables do not have public documentation as mainly used method will be `javacore_analyzer.process_javacores_and_generate_report_data`. I do not want to spend too much time on something I do not think will be frequently used in near future. The gap can be filled once there is a business need for this.

Also there is a missing update in README.md how to run API. I will add it once this is reviewed.