### PR TITLE
#27 there is no progress indicator on the web app

### DIFF
--- a/src/javacore_analyser/constants.py
+++ b/src/javacore_analyser/constants.py
@@ -37,3 +37,4 @@ DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 # Web application constants
 DEFAULT_REPORTS_DIR = "reports"
 DEFAULT_PORT = 5000
+TEMP_DIR = "temp_data" # Folder to store temporary data for creating reports

--- a/src/javacore_analyser/data/html/processing_data.html
+++ b/src/javacore_analyser/data/html/processing_data.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<!--
+# Copyright IBM Corp. 2024 - 2024
+# SPDX-License-Identifier: Apache-2.0
+-->
+
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="30" /> <!-- Refresh this page every 30s until generated page appears -->
+    <meta charset="UTF-8">
+    <title>The page is being generated</title>
+</head>
+<body>
+    <h1>The page is being generated. Once it is ready, it will appear here.</h1>
+</body>
+</html>

--- a/src/javacore_analyser/javacore_analyser_web.py
+++ b/src/javacore_analyser/javacore_analyser_web.py
@@ -105,7 +105,6 @@ def upload_file():
             raise Exception("Security exception: Uncontrolled data used in path expression")
         os.mkdir(javacores_temp_dir_name)
 
-
         # Get the list of files from webpage
         files = request.files.getlist("files")
 

--- a/src/javacore_analyser/javacore_analyser_web.py
+++ b/src/javacore_analyser/javacore_analyser_web.py
@@ -103,7 +103,7 @@ def upload_file():
         javacores_temp_dir_name = os.path.normpath(os.path.join(reports_dir, TEMP_DIR, report_name))
         if not javacores_temp_dir_name.startswith(reports_dir):
             raise Exception("Security exception: Uncontrolled data used in path expression")
-        javacores_temp_dir = os.mkdir(javacores_temp_dir_name)
+        os.mkdir(javacores_temp_dir_name)
 
 
         # Get the list of files from webpage
@@ -127,7 +127,7 @@ def upload_file():
         time.sleep(1) # Give 1 second to generate index.html in processing_thread before redirecting
         return redirect("/reports/" + report_name + "/index.html")
     finally:
-        shutil.rmtree(javacores_temp_dir, ignore_errors=True)
+        shutil.rmtree(javacores_temp_dir_name, ignore_errors=True)
 
 def main():
     debug = os.getenv("DEBUG", False)

--- a/src/javacore_analyser/javacore_analyser_web.py
+++ b/src/javacore_analyser/javacore_analyser_web.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -16,7 +17,7 @@ from flask import Flask, render_template, request, send_from_directory, redirect
 from waitress import serve
 
 import javacore_analyser.javacore_analyser_batch
-from javacore_analyser.constants import DEFAULT_REPORTS_DIR, DEFAULT_PORT
+from javacore_analyser.constants import DEFAULT_REPORTS_DIR, DEFAULT_PORT, TEMP_DIR
 from javacore_analyser.logging_utils import create_console_logging, create_file_logging
 
 """
@@ -25,6 +26,15 @@ export REPORTS_DIR=/tmp/reports
 flask --app javacore_analyser_web run
 """
 app = Flask(__name__)
+
+
+# Assisted by watsonx Code Assistant
+def create_temp_data_in_reports_dir(reports_dir):
+    tmp_reports_dir = os.path.join(reports_dir, TEMP_DIR)
+    if os.path.isdir(tmp_reports_dir):
+        shutil.rmtree(tmp_reports_dir, ignore_errors=True)
+    os.mkdir(tmp_reports_dir)
+
 with app.app_context():
     create_console_logging()
     logging.info("Javacore analyser")
@@ -33,12 +43,13 @@ with app.app_context():
     reports_dir = os.getenv("REPORTS_DIR", DEFAULT_REPORTS_DIR)
     logging.info("Reports directory: " + reports_dir)
     create_file_logging(reports_dir)
+    create_temp_data_in_reports_dir(reports_dir)
 
 
 @app.route('/')
 def index():
     reports = [{"name": Path(f).name, "date": time.ctime(os.path.getctime(f)), "timestamp": os.path.getctime(f)}
-               for f in os.scandir(reports_dir) if f.is_dir()]
+               for f in os.scandir(reports_dir) if f.is_dir() and Path(f).name is not TEMP_DIR]
     reports.sort(key=lambda item: item["timestamp"], reverse=True)
     return render_template('index.html', reports=reports)
 
@@ -83,9 +94,14 @@ def delete(path):
 @app.route('/upload', methods=['POST'])
 def upload_file():
     try:
+        report_name = request.values.get("report_name")
+        report_name = re.sub(r'[^a-zA-Z0-9]', '_', report_name)
+
         # Create a temporary directory to store uploaded files
-        javacores_temp_dir = tempfile.TemporaryDirectory()
-        javacores_temp_dir_name = javacores_temp_dir.name
+        # Note We have to use permanent files and then delete them.
+        # tempfile.Temporary directory function does not work when you want to access files from another threads.
+        javacores_temp_dir_name = os.path.join(reports_dir, TEMP_DIR, report_name)
+        javacores_temp_dir = os.mkdir(javacores_temp_dir_name)
 
         # Get the list of files from webpage
         files = request.files.getlist("files")
@@ -97,17 +113,18 @@ def upload_file():
             file.save(file_name)
             input_files.append(file_name)
 
-        report_name = request.values.get("report_name")
-        report_name = re.sub(r'[^a-zA-Z0-9]', '_', report_name)
-
         # Process the uploaded file
-        report_output_dir = reports_dir + '/' + report_name
-        javacore_analyser.javacore_analyser_batch.process_javacores_and_generate_report_data(input_files,
-                                                                                             report_output_dir)
+        report_output_dir = os.path.join(reports_dir, report_name)
+        processing_thread = threading.Thread(
+            target=javacore_analyser.javacore_analyser_batch.process_javacores_and_generate_report_data,
+            name="Processing javacore data", args=(input_files, report_output_dir)
+        )
+        processing_thread.start()
 
+        time.sleep(1) # Give 1 second to generate index.html in processing_thread before redirecting
         return redirect("/reports/" + report_name + "/index.html")
     finally:
-        javacores_temp_dir.cleanup()
+        shutil.rmtree(javacores_temp_dir, ignore_errors=True)
 
 def main():
     debug = os.getenv("DEBUG", False)

--- a/src/javacore_analyser/javacore_analyser_web.py
+++ b/src/javacore_analyser/javacore_analyser_web.py
@@ -99,9 +99,12 @@ def upload_file():
 
         # Create a temporary directory to store uploaded files
         # Note We have to use permanent files and then delete them.
-        # tempfile.Temporary directory function does not work when you want to access files from another threads.
-        javacores_temp_dir_name = os.path.join(reports_dir, TEMP_DIR, report_name)
+        # tempfile.Temporary_directory function does not work when you want to access files from another threads.
+        javacores_temp_dir_name = os.path.normpath(os.path.join(reports_dir, TEMP_DIR, report_name))
+        if not javacores_temp_dir_name.startswith(reports_dir):
+            raise Exception("Security exception: Uncontrolled data used in path expression")
         javacores_temp_dir = os.mkdir(javacores_temp_dir_name)
+
 
         # Get the list of files from webpage
         files = request.files.getlist("files")

--- a/src/javacore_analyser/javacore_analyser_web.py
+++ b/src/javacore_analyser/javacore_analyser_web.py
@@ -93,16 +93,18 @@ def delete(path):
 # Latest GenAI contribution: ibm/granite-20b-code-instruct-v2
 @app.route('/upload', methods=['POST'])
 def upload_file():
-    try:
-        report_name = request.values.get("report_name")
-        report_name = re.sub(r'[^a-zA-Z0-9]', '_', report_name)
 
-        # Create a temporary directory to store uploaded files
-        # Note We have to use permanent files and then delete them.
-        # tempfile.Temporary_directory function does not work when you want to access files from another threads.
-        javacores_temp_dir_name = os.path.normpath(os.path.join(reports_dir, TEMP_DIR, report_name))
-        if not javacores_temp_dir_name.startswith(reports_dir):
-            raise Exception("Security exception: Uncontrolled data used in path expression")
+    report_name = request.values.get("report_name")
+    report_name = re.sub(r'[^a-zA-Z0-9]', '_', report_name)
+
+    # Create a temporary directory to store uploaded files
+    # Note We have to use permanent files and then delete them.
+    # tempfile.Temporary_directory function does not work when you want to access files from another threads.
+    javacores_temp_dir_name = os.path.normpath(os.path.join(reports_dir, TEMP_DIR, report_name))
+    if not javacores_temp_dir_name.startswith(reports_dir):
+        raise Exception("Security exception: Uncontrolled data used in path expression")
+
+    try:
         os.mkdir(javacores_temp_dir_name)
 
         # Get the list of files from webpage

--- a/src/javacore_analyser/javacore_set.py
+++ b/src/javacore_analyser/javacore_set.py
@@ -146,6 +146,8 @@ class JavacoreSet:
         data_dir = os.path.dirname(style_css_resource)
         os.mkdir(data_output_dir)
         shutil.copytree(data_dir, data_output_dir, dirs_exist_ok=True)
+        shutil.copy2(os.path.join(data_output_dir, "html","processing_data.html"),
+                     os.path.join(output_dir, "index.html"))
 
     def __generate_htmls_for_threads(self, output_dir, temp_dir_name):
         _create_xml_xsl_for_collection(os.path.join(temp_dir_name, "threads"),

--- a/src/javacore_analyser/javacore_set.py
+++ b/src/javacore_analyser/javacore_set.py
@@ -126,10 +126,29 @@ class JavacoreSet:
         temp_dir_name = temp_dir.name
         logging.info("Created temp dir: " + temp_dir_name)
         self.__create_report_xml(temp_dir_name + "/report.xml")
+        placeholder_filename = os.path.join(output_dir, "data", "html", "processing_data.html")
+        self.__generate_placeholder_htmls(placeholder_filename,
+                                          os.path.join(output_dir, "threads"),
+                                          self.threads, "thread")
+        self.__generate_placeholder_htmls(placeholder_filename,
+                                          os.path.join(output_dir, "javacores"),
+                                          self.javacores, "")
+        self.__create_index_html(temp_dir_name, output_dir)
         self.__generate_htmls_for_threads(output_dir, temp_dir_name)
         self.__generate_htmls_for_javacores(output_dir, temp_dir_name)
-        self.__create_index_html(temp_dir_name, output_dir)
 
+
+    def __generate_placeholder_htmls(self, placeholder_file, dir, collection, file_prefix):
+        if os.path.exists(dir):
+            shutil.rmtree(dir)
+        os.mkdir(dir)
+
+        for element in tqdm(collection, desc="Generating placeholder htmls", unit=" file"):
+            filename = file_prefix + "_" + element.get_id() + ".html"
+            if filename.startswith("_"):
+                filename = filename[1:]
+            file_path = os.path.join(dir, filename)
+            shutil.copy2(placeholder_file, file_path)
 
 
     def __generate_htmls_for_threads(self, output_dir, temp_dir_name):

--- a/src/javacore_analyser/javacore_set.py
+++ b/src/javacore_analyser/javacore_set.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from xml.dom.minidom import parseString
 
 import importlib_resources
-from importlib_resources.abc import Traversable
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 from tqdm import tqdm
@@ -126,29 +125,12 @@ class JavacoreSet:
         temp_dir = tempfile.TemporaryDirectory()
         temp_dir_name = temp_dir.name
         logging.info("Created temp dir: " + temp_dir_name)
-        self.create_output_files_structure(output_dir)
         self.__create_report_xml(temp_dir_name + "/report.xml")
         self.__generate_htmls_for_threads(output_dir, temp_dir_name)
         self.__generate_htmls_for_javacores(output_dir, temp_dir_name)
         self.__create_index_html(temp_dir_name, output_dir)
 
-    @staticmethod
-    def create_output_files_structure(self, output_dir):
-        if not os.path.isdir(output_dir):
-            os.mkdir(output_dir)
-        data_output_dir = os.path.normpath(os.path.join(output_dir, 'data'))
-        if not data_output_dir.startswith(output_dir):
-            raise Exception("Security exception: Uncontrolled data used in path expression")
-        if os.path.isdir(data_output_dir):
-            shutil.rmtree(data_output_dir, ignore_errors=True)
-        logging.info("Data dir: " + data_output_dir)
 
-        style_css_resource: Traversable = importlib_resources.files("javacore_analyser") / "data" / "style.css"
-        data_dir = os.path.dirname(style_css_resource)
-        os.mkdir(data_output_dir)
-        shutil.copytree(data_dir, data_output_dir, dirs_exist_ok=True)
-        shutil.copy2(os.path.join(data_output_dir, "html","processing_data.html"),
-                     os.path.join(output_dir, "index.html"))
 
     def __generate_htmls_for_threads(self, output_dir, temp_dir_name):
         _create_xml_xsl_for_collection(os.path.join(temp_dir_name, "threads"),

--- a/src/javacore_analyser/javacore_set.py
+++ b/src/javacore_analyser/javacore_set.py
@@ -126,13 +126,14 @@ class JavacoreSet:
         temp_dir = tempfile.TemporaryDirectory()
         temp_dir_name = temp_dir.name
         logging.info("Created temp dir: " + temp_dir_name)
-        self.__create_output_files_structure(output_dir)
+        self.create_output_files_structure(output_dir)
         self.__create_report_xml(temp_dir_name + "/report.xml")
         self.__generate_htmls_for_threads(output_dir, temp_dir_name)
         self.__generate_htmls_for_javacores(output_dir, temp_dir_name)
         self.__create_index_html(temp_dir_name, output_dir)
 
-    def __create_output_files_structure(self, output_dir):
+    @staticmethod
+    def create_output_files_structure(self, output_dir):
         if not os.path.isdir(output_dir):
             os.mkdir(output_dir)
         data_output_dir = os.path.normpath(os.path.join(output_dir, 'data'))


### PR DESCRIPTION
Fixes #27 

The patch is doing the following:
1. Creates placeholder files for index.html and thread and javacores htmls. Placeholder file attached below. The file is being refreshed every 30s.
2. Makes generation of index.html before generating html files for threads and javacores so that you can have main page faster.
3. In web ui it it opens reports page a 1s after clicking upload report page. The user will see the placeholder page which will be refreshed and finally appear there proper index page (without user intervention needed). This change required introducing temp directory by using functions for persistent files in Python as tempfile.TemporaryDirectory does not work in a separate thread.

<img width="896" alt="image" src="https://github.com/user-attachments/assets/3484ddca-943d-4c4e-85d9-749a1496b6cb">
