### PR TITLE
Ref #60 use variables in web app

### DIFF
--- a/src/javacore_analyser/javacore_analyser_web.py
+++ b/src/javacore_analyser/javacore_analyser_web.py
@@ -2,6 +2,7 @@
 # Copyright IBM Corp. 2024 - 2024
 # SPDX-License-Identifier: Apache-2.0
 #
+import argparse
 import locale
 import logging
 import os
@@ -21,16 +22,16 @@ from javacore_analyser.logging_utils import create_console_logging, create_file_
 
 """
 To run the application from cmd type:
-export REPORTS_DIR=/tmp/reports
+
 flask --app javacore_analyser_web run
 """
 app = Flask(__name__)
+reports_dir = DEFAULT_REPORTS_DIR
 with app.app_context():
     create_console_logging()
     logging.info("Javacore analyser")
     logging.info("Python version: " + sys.version)
     logging.info("Preferred encoding: " + locale.getpreferredencoding())
-    reports_dir = os.getenv("REPORTS_DIR", DEFAULT_REPORTS_DIR)
     logging.info("Reports directory: " + reports_dir)
     create_file_logging(reports_dir)
 
@@ -110,8 +111,16 @@ def upload_file():
         javacores_temp_dir.cleanup()
 
 def main():
-    debug = os.getenv("DEBUG", False)
-    port = os.getenv("PORT", DEFAULT_PORT)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", help="Debug mode. Use only for development", default=False)
+    parser.add_argument("--port", help="Port to run application", default=DEFAULT_PORT)
+    parser.add_argument("--reports_dir", help="Directory where app reports are stored",
+                        default=DEFAULT_REPORTS_DIR)
+    args = parser.parse_args()
+    debug = args.debug
+    port = args.port
+    global reports_dir
+    reports_dir = args.reports_dir
     if debug:
         app.run(debug=True, port=port)  # Run Flask for development
     else:
@@ -119,9 +128,9 @@ def main():
 
 if __name__ == '__main__':
     """
-    The application passes the following environmental variables:
-    DEBUG (default: False) - defines if we should run an app in debug mode
-    PORT - application port
-    REPORTS_DIR - the directory when the reports are stored as default
+    The application passes the following parameters:
+    --debug (default: False) - defines if we should run an app in debug mode
+    --port - application port
+    --reports_dir - the directory when the reports are stored as default
     """
     main()


### PR DESCRIPTION
This patch changes the behavior to use cmd properties instead of venv to unify the behavior for both batch and web.

It does not change the behavior in .Docker as #48 is not merged yet. I have created #61 to track that change separately.