### PR TITLE
Fixes #60 Switch to use cmd properties in web app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,9 @@ Change the second parameter to the directory where you want the output report be
 
 To run web application:
 1. Right click on **javacore_analyser_web.py** directory in **Project** view and select **Modify Run Configuration...**.
-2. Add the following **Environmental variables:**
-   * **DEBUG:True**
-   * **REPORTS_DIR:/tmp/web_reports**  
+2. Add the following parameters:  
+   **debug=True reports_dir=/tmp/web_reports**  
+
    You can change the report dir to the location when you want to store the report. 
    The application will start on http://localhost:5000
 

--- a/README.md
+++ b/README.md
@@ -53,15 +53,11 @@ You can type the following command to obtain the help:
 
 #### Running web application:
 1. Repeat steps 1-3 from cmd application
-2. OPTIONAL: set the following variables:
-  ```
-  export REPORTS_DIR=/tmp/reports  
-  export PORT=5000
-  ``` 
- The first parameter sets where the reports need to be stored. If not set, then the `reports` dir will be created in current location.  
- The first parameter set the port to use by application. If not specified, 5000 will be used.  
-3. Execute the following command from cmd:  
-  `javacore_analyser_web`
+2. Execute the following command from cmd:  
+  `javacore_analyser_web --port=500 --reports-dir=/data/reports_dir`
+
+     The first parameter set the port to use by application. If not specified, 5000 will be used.  
+     The second parameter sets where the reports need to be stored. If not set, then the `reports` dir will be created in current location.  
 
   Now you can type (http://localhost:5000/).  
  

--- a/src/javacore_analyser/data/expand.js
+++ b/src/javacore_analyser/data/expand.js
@@ -15,6 +15,8 @@ $('.show').click(function () {
     }
 });
 
+
+
 function expand_it(whichEl, link) {
     whichEl.style.display = (whichEl.style.display == "none") ? "" : "none";
     //if (link) {


### PR DESCRIPTION
I corrected the pull request #62 

Fixes https://github.com/IBM/javacore-analyser/issues/60

This patch changes the behavior to use cmd properties instead of venv to unify the behavior for both batch and web.

You can use the following example parameters to start app:
javacore_analyser_web --port=5000 --reports-dir=/data/reports_dir

It does not change the behavior in .Docker as https://github.com/IBM/javacore-analyser/pull/48 is not merged yet. I have created https://github.com/IBM/javacore-analyser/issues/61 to track that change separately.