### PR TITLE
Ref #38 Generate pip package from travis for releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ before_install:
 # - pip install codecov
 install:
  - pip install -r requirements.txt
-# - pip install .
+ - pip install .
 env:
  global:
   - PYTHONPATH=src:test
 script:
 # - pytest
- - python -m build
+# - python -m build
 #after_success:
 # - codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ script:
 # - codecov
 deploy:
   provider: pypi
- # server: https://test.pypi.org
+  server: https://test.pypi.org
   edge: true # opt in to dpl v2
   skip_existing: true
-  # distributions: "sdist bdist_hatchling"
+  distributions: "bdist_hatchling"
   on:
    all_branches: true # For testing only. Comment once the script is running
  # tags: true # Uncomment this line to publish when the tag is created

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-# - "3.9"
+ - "3.9"
 # - "3.10"
 # - "3.11"
- - "3.12"
+# - "3.12"
 before_install:
  - pip install 'urllib3<2.0' #Enforce SSL version to be able to run twine
  - pip install -U pytest
@@ -20,7 +20,7 @@ script:
 # - pytest
  - python -m build
 after_success:
- - python -m twine upload --skip-existing --repository testpypi dist/*
+ - python -m twine upload --skip-existing --verbose --repository testpypi dist/*
 # - codecov
 #deploy:
 #  provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,12 @@ install:
 env:
  global:
   - PYTHONPATH=src:test
-script:
- - pytest
-after_success:
- - codecov
+#script:
+# - pytest
+#after_success:
+# - codecov
+deploy:
+  provider: pypi
+  server: https://test.pypi.org
+  edge: true # opt in to dpl v2
+  skip_existing: True

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 before_install:
  - pip install -U pytest
  - pip install -U build
+ - pip install --upgrade twine
 # - pip install codecov
 install:
  - pip install -r requirements.txt
@@ -18,15 +19,16 @@ env:
 script:
 # - pytest
  - python -m build
-#after_success:
+after_success:
+ - python -m twine upload --repository testpypi dist/*
 # - codecov
-deploy:
-  provider: pypi
-  server: https://test.pypi.org
-  edge: true # opt in to dpl v2
-  skip_existing: true
-  script: build.sh
-  distributions: "sdist bdist_wheel"
-  on:
-   all_branches: true # For testing only. Comment once the script is running
+#deploy:
+#  provider: pypi
+#  server: https://test.pypi.org
+#  edge: true # opt in to dpl v2
+#  skip_existing: true
+#  script: build.sh
+#  distributions: "sdist bdist_wheel"
+#  on:
+#   all_branches: true # For testing only. Comment once the script is running
  # tags: true # Uncomment this line to publish when the tag is created

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
  - "3.9"
-# - "3.10"
-# - "3.11"
-# - "3.12"
+ - "3.10"
+ - "3.11"
 before_install:
  - pip install 'urllib3<2.0' #Enforce SSL version to be able to run twine
  - pip install -U pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ env:
  global:
   - PYTHONPATH=src:test
 script:
-# - pytest
+ - pytest
  - python -m build
 after_success:
-# - python -m twine upload --skip-existing --verbose --repository testpypi dist/*
  - codecov
 deploy:
   provider: script
@@ -26,13 +25,3 @@ deploy:
    all_branches: true # uncomment for testing purposes
    #branch: prod # uncomment on production
    #tags: true # uncomment on production
- #deploy:
-#  provider: pypi
-#  server: https://test.pypi.org
-#  edge: true # opt in to dpl v2
-#  skip_existing: true
-#  script: build.sh
-#  distributions: "sdist bdist_wheel"
-#  on:
-#   all_branches: true # For testing only. Comment once the script is running
- # tags: true # Uncomment this line to publish when the tag is created

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: python
 python:
  - "3.9"
-install:
+before_install: install:
  - pip install -r requirements.txt
+ - pip install -U pytest
+ - pip install codecov
+install:
+ - pip install .
 env:
  global:
   - PYTHONPATH=src:test
 script:
- - make test
+ - pytest
+after_success:
+ - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ python:
 # - "3.13"
 before_install:
  - pip install -U pytest
- - pip install codecov
+# - pip install codecov
 install:
  - pip install -r requirements.txt
- - pip install .
+# - pip install .
 env:
  global:
   - PYTHONPATH=src:test
@@ -25,5 +25,6 @@ deploy:
   edge: true # opt in to dpl v2
   skip_existing: true
   distributions: "sdist bdist_hatchling"
-  #on:
-  # tags: true
+  on:
+   all_branches: true # For testing only. Comment once the script is running
+ # tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 # - "3.13"
 before_install:
  - pip install -U pytest
+ - pip install -U build
 # - pip install codecov
 install:
  - pip install -r requirements.txt
@@ -16,7 +17,7 @@ env:
   - PYTHONPATH=src:test
 script:
 # - pytest
-# - python -m build
+ - python -m build
 #after_success:
 # - codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ after_success:
  - codecov
 deploy:
   provider: script
-  script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
-  #script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
+  #script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
+  script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
   on:
    all_branches: true # uncomment for testing purposes
    # branch: prod # uncomment on production

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ deploy:
   provider: pypi
   server: https://test.pypi.org
   edge: true # opt in to dpl v2
-  skip_existing: True
+  skip_existing: true
+  distributions: "sdist bdist_hatchling"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ after_success:
  - codecov
 deploy:
   provider: script
-  script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
-  #script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
+  #script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
+  script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
   on:
    all_branches: true # uncomment for testing purposes
    #branch: prod # uncomment on production

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
 # - codecov
 deploy:
   provider: pypi
-  server: https://test.pypi.org
+ # server: https://test.pypi.org
   edge: true # opt in to dpl v2
   skip_existing: true
   # distributions: "sdist bdist_hatchling"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ install:
 env:
  global:
   - PYTHONPATH=src:test
-#script:
-# - pytest
+script:
+ - pytest
 #after_success:
 # - codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
  global:
   - PYTHONPATH=src:test
 script:
- - pytest
+# - pytest
+ - echo "next stage: deploy"
 #after_success:
 # - codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
  - "3.9"
-before_install: install:
- - pip install -r requirements.txt
+before_install:
  - pip install -U pytest
  - pip install codecov
 install:
+ - pip install -r requirements.txt
  - pip install .
 env:
  global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
  - "3.9"
- - "3.10"
- - "3.11"
 before_install:
  - pip install 'urllib3<2.0' #Enforce SSL version to be able to run twine
  - pip install -U pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ deploy:
   server: https://test.pypi.org
   edge: true # opt in to dpl v2
   skip_existing: true
-  distributions: "sdist bdist_hatchling"
+  # distributions: "sdist bdist_hatchling"
   on:
    all_branches: true # For testing only. Comment once the script is running
  # tags: true # Uncomment this line to publish when the tag is created

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ deploy:
   #script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
   script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
   on:
-   all_branches: true # uncomment for testing purposes
-   # branch: prod # uncomment on production
-   # tags: true # uncomment on production
+   # all_branches: true # uncomment for testing purposes
+   branch: prod # uncomment on production
+   # tags: true # We need to consider if we want to publish all versions or every build (which should not be an issue

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ env:
  global:
   - PYTHONPATH=src:test
 script:
- - python -m unittest test.test_javacore test.test_thread_snapshot test.test_javacore_set test.test_java_thread test.test_stack_trace test.test_javacore_analyser test.test_tips test.test_verbose_gc_parser test.test_gc_collection test.test_code_snapshot_collection
+ - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
-# - "3.9"
+ - "3.9"
 # - "3.10"
 # - "3.11"
 # - "3.12"
- - "3.13"
+# - "3.13"
 before_install:
- - pip install urllib3==1.26.6 #Enforce SSL version to be able to run twine
+ - pip install 'urllib3<2.0' #Enforce SSL version to be able to run twine
  - pip install -U pytest
  - pip install -U build
  - pip install --upgrade twine

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
- - "3.9"
+# - "3.9"
 # - "3.10"
 # - "3.11"
-# - "3.12"
-# - "3.13"
+ - "3.12"
 before_install:
  - pip install 'urllib3<2.0' #Enforce SSL version to be able to run twine
  - pip install -U pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ deploy:
   distributions: "sdist bdist_hatchling"
   on:
    all_branches: true # For testing only. Comment once the script is running
- # tags: true
+ # tags: true # Uncomment this line to publish when the tag is created

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ deploy:
   edge: true # opt in to dpl v2
   skip_existing: true
   distributions: "sdist bdist_hatchling"
+  #on:
+  # tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - PYTHONPATH=src:test
 script:
 # - pytest
- - python -V
+ - python -m build
 #after_success:
 # - codecov
 deploy:
@@ -24,8 +24,7 @@ deploy:
   server: https://test.pypi.org
   edge: true # opt in to dpl v2
   skip_existing: true
-  distributions: "bdist_hatchling"
-  script: python -m build
+  distributions: "sdist bdist_wheel"
   on:
    all_branches: true # For testing only. Comment once the script is running
  # tags: true # Uncomment this line to publish when the tag is created

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
  - pip install 'urllib3<2.0' #Enforce SSL version to be able to run twine
  - pip install -U pytest
  - pip install -U build
- - pip install --upgrade twine
-# - pip install codecov
+ - pip install -U twine
+ - pip install codecov
 install:
  - pip install -r requirements.txt
  - pip install .
@@ -17,9 +17,16 @@ script:
 # - pytest
  - python -m build
 after_success:
- - python -m twine upload --skip-existing --verbose --repository testpypi dist/*
-# - codecov
-#deploy:
+# - python -m twine upload --skip-existing --verbose --repository testpypi dist/*
+ - codecov
+deploy:
+  provider: script
+  script: python -m twine upload --skip-existing --verbose --repository testpypi dist/*
+  on:
+   all_branches: true # uncomment for testing purposes
+   #branch: prod # uncomment on production
+   #tags: true # uncomment on production
+ #deploy:
 #  provider: pypi
 #  server: https://test.pypi.org
 #  edge: true # opt in to dpl v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 # - "3.12"
 # - "3.13"
 before_install:
+ - pip install urllib3==1.26.6 #Enforce SSL version to be able to run twine
  - pip install -U pytest
  - pip install -U build
  - pip install --upgrade twine
@@ -20,7 +21,7 @@ script:
 # - pytest
  - python -m build
 after_success:
- - python -m twine upload --repository testpypi dist/*
+ - python -m twine upload --skip-existing --repository testpypi dist/*
 # - codecov
 #deploy:
 #  provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
  - pip install -U pytest
  - pip install -U build
  - pip install -U twine
- - pip install codecov
 install:
  - pip install -r requirements.txt
  - pip install .
@@ -16,8 +15,6 @@ env:
 script:
  - pytest
  - python -m build
-after_success:
- - codecov
 deploy:
   provider: script
   #script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 python:
  - "3.9"
+# - "3.10"
+# - "3.11"
+# - "3.12"
+# - "3.13"
 before_install:
  - pip install -U pytest
  - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
- - "3.9"
+# - "3.9"
 # - "3.10"
 # - "3.11"
 # - "3.12"
-# - "3.13"
+ - "3.13"
 before_install:
  - pip install urllib3==1.26.6 #Enforce SSL version to be able to run twine
  - pip install -U pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ after_success:
  - codecov
 deploy:
   provider: script
-  script: python -m twine upload --skip-existing --verbose --repository testpypi dist/*
+  script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
+  #script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
   on:
    all_branches: true # uncomment for testing purposes
    #branch: prod # uncomment on production

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ deploy:
   edge: true # opt in to dpl v2
   skip_existing: true
   distributions: "bdist_hatchling"
+  script: python -m build
   on:
    all_branches: true # For testing only. Comment once the script is running
  # tags: true # Uncomment this line to publish when the tag is created

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ deploy:
   on:
    all_branches: true # uncomment for testing purposes
    # branch: prod # uncomment on production
-   tags: true # uncomment on production
+   # tags: true # uncomment on production

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ deploy:
   server: https://test.pypi.org
   edge: true # opt in to dpl v2
   skip_existing: true
+  script: build.sh
   distributions: "sdist bdist_wheel"
   on:
    all_branches: true # For testing only. Comment once the script is running

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - PYTHONPATH=src:test
 script:
 # - pytest
- - echo "next stage: deploy"
+ - python -V
 #after_success:
 # - codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ after_success:
  - codecov
 deploy:
   provider: script
-  #script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
-  script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
+  script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
+  #script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
   on:
    all_branches: true # uncomment for testing purposes
-   #branch: prod # uncomment on production
-   #tags: true # uncomment on production
+   # branch: prod # uncomment on production
+   tags: true # uncomment on production


### PR DESCRIPTION
Fixes #38 

This pull requests causes publishing a new pip release.

In order to test it, change the following lines:
```
deploy:
 - provider: script
   script: python -m twine upload --skip-existing --verbose --password $TWINE_TEST_TOKEN --repository testpypi dist/* #test instance
   # script: python -m twine upload --skip-existing --verbose --password $TWINE_PROD_TOKEN dist/* #production instance.
   on:
     all_branches: true # uncomment for testing purposes
     # branch: prod # uncomment on production
     tags: true # We need to consider if we want to publish all versions or every build (which should not be an issue
```

I would suggest merging all these changes as one commit.

Then create a new tag e.g. 2.1rc6 and push the tag. The new release on https://test.pypi.org/project/javacore-analyser/#history should appear.