### PR TITLE
Fixes #99 do not include test dir to source package for pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 [project]
 dynamic = ["version"]
 name = "javacore_analyser"
-#version = "2.0rc1"
+#version = "2.2rc1"
 authors = [
     { name="Krzysztof Kazmierczyk", email="kazm@ibm.com" },
     { name="Piotr Aniola", email="Piotr.Aniola@ibm.com" },
@@ -58,6 +58,11 @@ Homepage = "https://github.com/IBM/javacore-analyser"
 Issues = "https://github.com/IBM/javacore-analyser/issues"
 Changelog = "https://github.com/IBM/javacore-analyser/blob/main/CHANGELOG.md"
 Source = "https://github.com/IBM/javacore-analyser"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/test",
+]
 
 [tool.hatch.version]
 source = "versioningit"


### PR DESCRIPTION
Fixes #99 

You can run not `python3 -m build`. You will see that the size of tar.gz file will have the size in kb.