### PR TITLE
Removing vagueness

### DIFF
--- a/src/javacore_analyser/templates/index.html
+++ b/src/javacore_analyser/templates/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-# Copyright IBM Corp. 2024 - 2024
+# Copyright IBM Corp. 2024 - 2025
 # SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/src/javacore_analyser/templates/index.html
+++ b/src/javacore_analyser/templates/index.html
@@ -18,9 +18,9 @@
     <h1>Generate report:</h1>
     <form action="/upload" method="post" enctype="multipart/form-data">
       <ol>
-      <li>One or more javacores:</br>
-        zero or more verbose.gc files:</br>
-        files can be either individual or in an archive
+      <li>One or more javacores;</br>
+        zero or more verbose.gc files;</br>
+        Note: files can be either individual or in an archive
         <input type="file" name="files" multiple required>
       </li>
       <li>Give the name for your report: <input type="text" id="report_name" name="report_name" required></li>

--- a/src/javacore_analyser/templates/index.html
+++ b/src/javacore_analyser/templates/index.html
@@ -15,10 +15,12 @@
   <body>
     <h1>Javacore Analyser</h1>
 
-    <h2>Generate report:</h2>
+    <h1>Generate report:</h1>
     <form action="/upload" method="post" enctype="multipart/form-data">
       <ol>
-      <li>Choose archive (zip, 7z, tgz, bz2) file or multiple javacore files:
+      <li>One or more javacores:</br>
+        zero or more verbose.gc files:</br>
+        files can be either individual or in an archive
         <input type="file" name="files" multiple required>
       </li>
       <li>Give the name for your report: <input type="text" id="report_name" name="report_name" required></li>


### PR DESCRIPTION
Removing vagueness

Describe the bug
The web app is vague in terms of the files required by the user to upload.
It actually requires

one or more javacores
zero or more verbose.gc files
files can be either individual or in an archive
To Reproduce
Steps to reproduce the behavior:

Run javacore_analyser_web
Go to http://127.0.0.1:5000/
Actual behaviour
Label next to Browse button says Archive file or multiple javacore files