### PR TITLE
#129 Set absolute path for reports dir.

### DIFF
--- a/src/javacore_analyser/javacore_analyser_web.py
+++ b/src/javacore_analyser/javacore_analyser_web.py
@@ -1,5 +1,5 @@
 #
-# Copyright IBM Corp. 2024 - 2024
+# Copyright IBM Corp. 2024 - 2025
 # SPDX-License-Identifier: Apache-2.0
 #
 import argparse
@@ -49,6 +49,7 @@ def index():
 @app.route('/reports/<path:path>')
 def dir_listing(path):
     return send_from_directory(reports_dir, path)
+
 
 
 @app.route('/zip/<path:path>')
@@ -139,7 +140,7 @@ def main():
 
 def run_web(debug=False, port=5000, reports_directory=DEFAULT_REPORTS_DIR):
     global reports_dir
-    reports_dir = reports_directory
+    reports_dir = os.path.abspath(reports_directory)
     create_console_logging()
     logging.info("Javacore analyser")
     logging.info("Python version: " + sys.version)

--- a/src/javacore_analyser/javacore_analyser_web.py
+++ b/src/javacore_analyser/javacore_analyser_web.py
@@ -51,7 +51,6 @@ def dir_listing(path):
     return send_from_directory(reports_dir, path)
 
 
-
 @app.route('/zip/<path:path>')
 def compress(path):
     temp_zip_dir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
Fixes #129 To test the fix, you need to build the version:
python -m build .
Then install built version:
pip install <your-project>/dist/*.whl
And then run:
javacore_analyser_web --port=5001 --reports-dir=reports
it is important to have reports-dir as relative path.
Now opening existing report will start working back.