### PR TITLE
#167 add collector file to release assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
  global:
   - PYTHONPATH=src:test
 script:
- - python -m unittest discover
+# - python -m unittest discover
  - python -m build
  #- docker build .
 deploy:
@@ -30,6 +30,6 @@ deploy:
     - dist/*
     - collectors/*
    on:
-    # all_branches: true # uncomment for testing purposes
+    all_branches: true # uncomment for testing purposes
     # branch: main # uncomment on production
-    tags: true # We need to consider if we want to publish all versions or every build
+    # tags: true # We need to consider if we want to publish all versions or every build

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ deploy:
  - provider: releases
    edge: true
    draft: true
-   file: dist/*
+   file: 
+    - dist/*
+    - collectors/*
    on:
     # all_branches: true # uncomment for testing purposes
     # branch: main # uncomment on production

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
  global:
   - PYTHONPATH=src:test
 script:
-# - python -m unittest discover
+ - python -m unittest discover
  - python -m build
  #- docker build .
 deploy:
@@ -30,6 +30,6 @@ deploy:
     - dist/*
     - collectors/*
    on:
-    all_branches: true # uncomment for testing purposes
+    # all_branches: true # uncomment for testing purposes
     # branch: main # uncomment on production
-    # tags: true # We need to consider if we want to publish all versions or every build
+    tags: true # We need to consider if we want to publish all versions or every build


### PR DESCRIPTION
Fixes #167 

I have tested it in the following travis build: https://app.travis-ci.com/github/IBM/javacore-analyser/builds/276158495. It shows, that the file javacoreCollector.sh is copied. See log file here: https://api.travis-ci.com/v3/job/635000647/log.txt. I have removed a draft release created for this.

With current code you can only change it when creating new release.