### PR TITLE
Fix #202: Create specific exception for invalid LLM method

### DIFF
--- a/src/javacore_analyser/exceptions.py
+++ b/src/javacore_analyser/exceptions.py
@@ -1,0 +1,29 @@
+#
+# Copyright IBM Corp. 2026 - 2026
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+class InvalidLLMMethodError(ValueError):
+    """
+    Exception raised when an invalid LLM method is specified.
+    
+    This exception is raised when the LLM method provided is not one of the
+    supported methods (e.g., 'ollama' or 'huggingface').
+    """
+    
+    def __init__(self, llm_method: str, supported_methods: list = None):
+        """
+        Initialize the InvalidLLMMethodError.
+        
+        Args:
+            llm_method: The invalid LLM method that was provided
+            supported_methods: Optional list of supported LLM methods
+        """
+        self.llm_method = llm_method
+        self.supported_methods = supported_methods or ['ollama', 'huggingface']
+        
+        message = f"Invalid LLM method: '{llm_method}'. Supported methods are: {', '.join(self.supported_methods)}"
+        super().__init__(message)
+
+# Made with Bob

--- a/src/javacore_analyser/javacore_set.py
+++ b/src/javacore_analyser/javacore_set.py
@@ -26,6 +26,7 @@ from javacore_analyser.ai.ollama_llm import OllamaLLM
 from javacore_analyser.ai.tips_prompter import TipsPrompter
 from javacore_analyser.code_snapshot_collection import CodeSnapshotCollection
 from javacore_analyser.constants import *
+from javacore_analyser.exceptions import InvalidLLMMethodError
 from javacore_analyser.har_file import HarFile
 from javacore_analyser.java_thread import Thread
 from javacore_analyser.javacore import Javacore
@@ -740,7 +741,7 @@ class JavacoreSet:
         llm_method = Properties.get_instance().get_property("llm_method")
         if llm_method.lower() == "huggingface": ai = HuggingFaceLLM(self)
         elif llm_method.lower() == "ollama": ai = OllamaLLM(self)
-        else: raise Exception("Invalid LLM method: " + llm_method)
+        else: raise InvalidLLMMethodError(llm_method)
             
         self.ai_overview = ai.infuse_in_html(AiOverviewPrompter(self))
         self.ai_tips = ai.infuse_in_html(TipsPrompter(self))

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,0 +1,39 @@
+#
+# Copyright IBM Corp. 2026 - 2026
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import unittest
+
+from javacore_analyser.exceptions import InvalidLLMMethodError
+
+
+class TestExceptions(unittest.TestCase):
+    """Test cases for custom exceptions."""
+
+    def test_invalid_llm_method_error_message(self):
+        """Test that InvalidLLMMethodError generates the correct error message."""
+        error = InvalidLLMMethodError("invalid_method")
+        expected_message = "Invalid LLM method: 'invalid_method'. Supported methods are: ollama, huggingface"
+        self.assertEqual(str(error), expected_message)
+
+    def test_invalid_llm_method_error_attributes(self):
+        """Test that InvalidLLMMethodError stores the correct attributes."""
+        error = InvalidLLMMethodError("invalid_method")
+        self.assertEqual(error.llm_method, "invalid_method")
+        self.assertEqual(error.supported_methods, ['ollama', 'huggingface'])
+
+    def test_invalid_llm_method_error_custom_supported_methods(self):
+        """Test InvalidLLMMethodError with custom supported methods."""
+        custom_methods = ['method1', 'method2', 'method3']
+        error = InvalidLLMMethodError("invalid", custom_methods)
+        self.assertEqual(error.supported_methods, custom_methods)
+        expected_message = "Invalid LLM method: 'invalid'. Supported methods are: method1, method2, method3"
+        self.assertEqual(str(error), expected_message)
+
+    def test_invalid_llm_method_error_is_value_error(self):
+        """Test that InvalidLLMMethodError is a subclass of ValueError."""
+        error = InvalidLLMMethodError("invalid")
+        self.assertIsInstance(error, ValueError)
+
+# Made with Bob


### PR DESCRIPTION
## Description
This PR addresses issue #202 by replacing the generic `Exception` with a specific `InvalidLLMMethodError` exception when an invalid LLM method is provided.

## Changes
- Created new `exceptions.py` module with `InvalidLLMMethodError` class
- `InvalidLLMMethodError` extends `ValueError` for semantic correctness
- Updated `javacore_set.py` to import and use the new exception
- Added comprehensive unit tests in `test_exceptions.py`
- Exception provides clear error messages listing supported methods

## Rationale
Using generic `Exception` is bad practice as it:
- Makes error handling less precise
- Provides less context about the error type
- Makes it harder to catch specific errors

The new `InvalidLLMMethodError`:
- Extends `ValueError` (appropriate for invalid input values)
- Provides clear error messages with supported methods
- Stores the invalid method and supported methods as attributes
- Follows Python exception best practices

## Testing
- ✅ All 4 new unit tests pass
- ✅ Tests verify exception message, attributes, and inheritance
- ✅ Exception properly extends `ValueError`

Fixes #202