### PR TITLE
#251 Add support for long GC pause detection

### DIFF
--- a/src/javacore_analyser/tips.py
+++ b/src/javacore_analyser/tips.py
@@ -210,7 +210,6 @@ class HighCpuUsageTip:
         return result
 
 
-
 class LongGcPauseTip:
     # Generates a tip when GC pauses exceed configurable thresholds
     

--- a/src/javacore_analyser/tips.py
+++ b/src/javacore_analyser/tips.py
@@ -9,7 +9,7 @@ import logging
 
 # List of the tips on which run the tool
 TIPS_LIST = ["DifferentIssuesTip", "ExcludedJavacoresTip", "InvalidAccumulatedCpuTimeTip", "TooFewJavacoresTip",
-             "OOMEGenerationTip", "BlockingThreadsTip", "HighCpuUsageTip"]
+             "OOMEGenerationTip", "BlockingThreadsTip", "HighCpuUsageTip", "LongGcPauseTip"]
 
 
 class TestTip:
@@ -208,3 +208,59 @@ class HighCpuUsageTip:
         if has_gc_performance_issues:
             result.append(HighCpuUsageTip.HIGH_GC_USAGE_TEXT)
         return result
+
+
+
+class LongGcPauseTip:
+    # Generates a tip when GC pauses exceed configurable thresholds
+    
+    # Configurable thresholds in milliseconds
+    THRESHOLD_1 = 1000  # 1 second
+    THRESHOLD_2 = 2000  # 2 seconds
+    
+    LONG_GC_PAUSE_WARNING = """[WARNING] Detected {0} GC pause(s) longer than {1}ms and {2} GC pause(s) longer than {3}ms.
+    The longest GC pause was {4:.0f}ms at {5}.
+    Long GC pauses can cause performance issues and application freezes."""
+    
+    NO_VERBOSE_GC_INFO = """[INFO] No verbose GC data available. Cannot analyze GC pause times."""
+    
+    @staticmethod
+    def generate(javacore_set):
+        # Get all GC collections from the parser
+        collects = javacore_set.gc_parser.get_collects()
+        
+        if not collects:
+            return []  # No verbose GC data, return empty tip
+        
+        # Count pauses exceeding thresholds
+        pauses_over_threshold_1 = 0
+        pauses_over_threshold_2 = 0
+        longest_pause = 0.0
+        longest_pause_time = ""
+        
+        for collect in collects:
+            duration = collect.duration
+            
+            if duration > LongGcPauseTip.THRESHOLD_1:
+                pauses_over_threshold_1 += 1
+            
+            if duration > LongGcPauseTip.THRESHOLD_2:
+                pauses_over_threshold_2 += 1
+            
+            if duration > longest_pause:
+                longest_pause = duration
+                longest_pause_time = collect.start_time_str
+        
+        # Generate warning if any pauses exceed threshold 1
+        if pauses_over_threshold_1 > 0:
+            msg = LongGcPauseTip.LONG_GC_PAUSE_WARNING.format(
+                pauses_over_threshold_1,
+                LongGcPauseTip.THRESHOLD_1,
+                pauses_over_threshold_2,
+                LongGcPauseTip.THRESHOLD_2,
+                longest_pause,
+                longest_pause_time
+            )
+            return [msg]
+        
+        return []  # No long pauses detected

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -178,7 +178,6 @@ class TestTips(unittest.TestCase):
         failure_message = "There should be no tip as all threads are with valid total CPU"
         self.assertTrue(result == expected_result, failure_message)
 
-
     def test_LongGcPauseTip_no_verbose_gc(self):
         """Test LongGcPauseTip when no verbose GC data is available"""
         javacore_set = JavacoreSet("")

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -1,5 +1,5 @@
 #
-# Copyright IBM Corp. 2024 - 2024
+# Copyright IBM Corp. 2024 - 2026
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -13,6 +13,8 @@ from javacore_analyser import tips
 from javacore_analyser.java_thread import Thread
 from javacore_analyser.javacore_set import JavacoreSet
 from javacore_analyser.thread_snapshot import ThreadSnapshot
+
+from javacore_analyser.verbose_gc import GcCollection
 
 
 class TestTips(unittest.TestCase):
@@ -175,3 +177,67 @@ class TestTips(unittest.TestCase):
         expected_result = []
         failure_message = "There should be no tip as all threads are with valid total CPU"
         self.assertTrue(result == expected_result, failure_message)
+
+
+    def test_LongGcPauseTip_no_verbose_gc(self):
+        """Test LongGcPauseTip when no verbose GC data is available"""
+        javacore_set = JavacoreSet("")
+        result = tips.LongGcPauseTip.generate(javacore_set)
+        self.assertEqual(0, len(result), "Should return empty list when no verbose GC data")
+
+    def test_LongGcPauseTip_no_long_pauses(self):
+        """Test LongGcPauseTip when all GC pauses are below threshold"""
+        from javacore_analyser.verbose_gc import GcCollection
+        
+        javacore_set = JavacoreSet("")
+        
+        # Create mock GC collections with short pauses
+        collect1 = GcCollection()
+        collect1.duration = 500.0  # 500ms - below threshold
+        collect1.start_time_str = "2023-04-25T11:04:13.857"
+        
+        collect2 = GcCollection()
+        collect2.duration = 800.0  # 800ms - below threshold
+        collect2.start_time_str = "2023-04-25T11:04:14.857"
+        
+        javacore_set.gc_parser._VerboseGcParser__collects = [collect1, collect2]
+        
+        result = tips.LongGcPauseTip.generate(javacore_set)
+        self.assertEqual(0, len(result), "Should return empty list when no long pauses")
+
+    def test_LongGcPauseTip_with_long_pauses(self):
+        """Test LongGcPauseTip when GC pauses exceed thresholds"""
+        
+        javacore_set = JavacoreSet("")
+        
+        # Create mock GC collections with long pauses
+        collect1 = GcCollection()
+        collect1.duration = 1200.0  # 1200ms - exceeds threshold 1
+        collect1.start_time_str = "2023-04-25T11:04:13.857"
+        
+        collect2 = GcCollection()
+        collect2.duration = 2500.0  # 2500ms - exceeds both thresholds
+        collect2.start_time_str = "2023-04-25T11:04:15.857"
+        
+        collect3 = GcCollection()
+        collect3.duration = 1500.0  # 1500ms - exceeds threshold 1
+        collect3.start_time_str = "2023-04-25T11:04:17.857"
+        
+        collect4 = GcCollection()
+        collect4.duration = 500.0  # 500ms - below threshold
+        collect4.start_time_str = "2023-04-25T11:04:18.857"
+        
+        javacore_set.gc_parser._VerboseGcParser__collects = [collect1, collect2, collect3, collect4]
+        
+        result = tips.LongGcPauseTip.generate(javacore_set)
+        self.assertEqual(1, len(result), "Should return one warning message")
+        
+        tip_text = result[0]
+        self.assertIn("[WARNING]", tip_text, "Tip should contain WARNING")
+        self.assertIn("3 GC pause(s) longer than 1000ms", tip_text, 
+                     "Should report 3 pauses over 1000ms threshold")
+        self.assertIn("1 GC pause(s) longer than 2000ms", tip_text,
+                     "Should report 1 pause over 2000ms threshold")
+        self.assertIn("2500", tip_text, "Should report longest pause of 2500ms")
+        self.assertIn("2023-04-25T11:04:15.857", tip_text, 
+                     "Should report timestamp of longest pause")


### PR DESCRIPTION
Fixes #251

## Summary
This PR adds a new tip (`LongGcPauseTip`) that detects and warns about long GC pauses in verbose GC data.

## Changes
- Created `LongGcPauseTip` class that analyzes GC pause durations
- Configurable thresholds: 1000ms and 2000ms
- Reports:
  - Count of pauses exceeding each threshold
  - Longest pause duration and timestamp
- Added `LongGcPauseTip` to `TIPS_LIST` for automatic execution
- Added comprehensive unit tests covering multiple scenarios

## Testing
- All existing tests pass (6 tests)
- Added 3 new tests for `LongGcPauseTip`:
  - No verbose GC data scenario
  - No long pauses scenario
  - Multiple long pauses with different durations
- Total: 9 tests passing

## Benefits
Users will now receive automatic warnings when GC pauses exceed thresholds, helping identify performance issues that might be overlooked when reviewing charts manually.