### PR TITLE
#253 Add gc pause time to ai prompt

### DIFF
--- a/src/javacore_analyser/ai/performance_recommendations_prompter.py
+++ b/src/javacore_analyser/ai/performance_recommendations_prompter.py
@@ -4,6 +4,7 @@
 #
 
 from javacore_analyser.ai.prompter import Prompter
+from javacore_analyser.constants import GC_PAUSE_DETAIL_THRESHOLD
 
 
 class PerformanceRecommendationsPrompter(Prompter):
@@ -44,6 +45,9 @@ class PerformanceRecommendationsPrompter(Prompter):
         # Get GC thread CPU usage
         gc_cpu_usage: str = self._get_gc_cpu_usage()
         
+        # Get GC pause times
+        gc_pause_times: str = self._get_gc_pause_times()
+        
         # Load the prompt template from file
         template: str = self._load_prompt_template('performance_recommendations_prompt.txt')
         
@@ -54,7 +58,8 @@ class PerformanceRecommendationsPrompter(Prompter):
             app_params=app_params,
             top_cpu_threads=top_cpu_threads,
             top_blocking_threads=top_blocking_threads,
-            gc_cpu_usage=gc_cpu_usage
+            gc_cpu_usage=gc_cpu_usage,
+            gc_pause_times=gc_pause_times
         )
 
         return prompt
@@ -232,3 +237,53 @@ class PerformanceRecommendationsPrompter(Prompter):
         return ", ".join(gc_info)
 
 # Made with Bob
+
+
+    def _get_gc_pause_times(self):
+        """
+        Collects detailed GC pause time statistics including long pauses.
+        For small datasets (< 100 pauses), shows individual pause times.
+        For large datasets (>= 100 pauses), shows summary statistics.
+        
+        Returns:
+            str: Formatted GC pause time information
+        """
+        if not self.javacore_set.gc_parser or not self.javacore_set.gc_parser.get_collects():
+            return "No GC pause data available"
+        
+        collects = self.javacore_set.gc_parser.get_collects()
+        if not collects:
+            return "No GC collections recorded"
+        
+        # Threshold for switching between detailed and summary view
+        if len(collects) < GC_PAUSE_DETAIL_THRESHOLD:
+            # Show individual pause times with timestamps
+            pause_details = []
+            for collect in collects:
+                pause_details.append(f"{collect.start_time_str}:{collect.duration:.0f}ms")
+            return ", ".join(pause_details)
+        else:
+            # Show summary statistics for large datasets
+            pause_times = [c.duration for c in collects]
+            avg_pause = sum(pause_times) / len(pause_times)
+            max_pause = max(pause_times)
+            min_pause = min(pause_times)
+            
+            # Count pauses exceeding thresholds (1000ms and 2000ms)
+            pauses_over_1s = sum(1 for p in pause_times if p > 1000)
+            pauses_over_2s = sum(1 for p in pause_times if p > 2000)
+            
+            # Find the longest pause with timestamp
+            longest_collect = max(collects, key=lambda c: c.duration)
+            longest_pause_time = longest_collect.start_time_str
+            
+            pause_info = [
+                f"Total GC pauses: {len(collects)}",
+                f"Average GC pause: {avg_pause:.2f}ms",
+                f"Min GC pause: {min_pause:.2f}ms",
+                f"Max GC pause: {max_pause:.2f}ms at {longest_pause_time}",
+                f"Pauses > 1000ms: {pauses_over_1s}",
+                f"Pauses > 2000ms: {pauses_over_2s}"
+            ]
+            
+            return ", ".join(pause_info)

--- a/src/javacore_analyser/constants.py
+++ b/src/javacore_analyser/constants.py
@@ -41,3 +41,8 @@ TEMP_DIR = "temp_data"  # Folder to store temporary data for creating reports
 # Used for extracting hugging face llm. See more on https://huggingface.co/ibm-granite/granite-4.0-micro
 ASSISTANT_ROLE = '<|start_of_role|>assistant<|end_of_role|>'
 END_OF_TEXT = '<|end_of_text|>'
+
+# GC pause time reporting threshold
+# When number of GC pauses is below this threshold, individual pause times are displayed
+# When above, summary statistics are shown instead
+GC_PAUSE_DETAIL_THRESHOLD = 100

--- a/src/javacore_analyser/data/prompts/performance_recommendations_prompt.txt
+++ b/src/javacore_analyser/data/prompts/performance_recommendations_prompt.txt
@@ -1,3 +1,7 @@
+Facts:
+The recommended maximum garbage collection (GC) pause time is typically set between 500 to 2000 milliseconds. 
+This range helps in managing application latency and throughput effectively.
+
 Context:
 CPU usage of entire application over time:
 {cpu_usage_data}

--- a/src/javacore_analyser/data/prompts/performance_recommendations_prompt.txt
+++ b/src/javacore_analyser/data/prompts/performance_recommendations_prompt.txt
@@ -1,17 +1,19 @@
 Context:
-CPU usage of entire application over time: 
+CPU usage of entire application over time:
 {cpu_usage_data}
-Memory usage by the application: 
+Memory usage by the application:
 {memory_info}
-Application parameters: 
+Application parameters:
 {app_params}
 
-Top threads using most of CPU: 
+Top threads using most of CPU:
 {top_cpu_threads}
-Top 5 blocking threads: 
+Top 5 blocking threads:
 {top_blocking_threads}
-GC Threads CPU usage: 
+GC Threads CPU usage:
 {gc_cpu_usage}
+GC Pause Times:
+{gc_pause_times}
 
 Based on that data search for potential bottlenecks and provide the recommendations how the performance can be improved.
 Limit to maximum 5 recommendations.


### PR DESCRIPTION
Fixes #253

## Summary
- add GC pause time data to the AI performance recommendations prompt
- include detailed per-collection pause entries for smaller GC datasets
- include summarized pause statistics for larger GC datasets
- add reference guidance that typical GC pause targets are in the 500-2000 ms range

## Details
- PerformanceRecommendationsPrompter now computes GC pause context and injects it into the prompt
- for fewer than 100 GC collections, the prompt receives timestamped pause durations
- for 100 or more GC collections, the prompt receives summary metrics including total count, average, min, max, and counts over 1000 ms and 2000 ms
- the prompt template was updated to include a dedicated GC Pause Times section
- a new constant is used to control the threshold between detailed and summarized output