### PR TITLE
#265 Flask import error in batch mode when Flask not installed

### DIFF
--- a/src/javacore_analyser/__main__.py
+++ b/src/javacore_analyser/__main__.py
@@ -1,10 +1,10 @@
 #
-# Copyright IBM Corp. 2024 - 2025
+# Copyright IBM Corp. 2024 - 2026
 # SPDX-License-Identifier: Apache-2.0
 #
 import argparse
 
-from javacore_analyser import javacore_analyser_batch, common_utils, javacore_analyser_web
+from javacore_analyser import javacore_analyser_batch, common_utils
 from javacore_analyser.properties import Properties
 
 
@@ -29,7 +29,13 @@ def main():
 
     if app_type.lower() == "web":
         print("Running web application")
-        javacore_analyser_web.run_web(args.debug, args.port, args.reports_dir, ai=Properties.get_instance().get_property("use_ai"))
+        try:
+            from javacore_analyser import javacore_analyser_web
+            javacore_analyser_web.run_web(args.debug, args.port, args.reports_dir, ai=Properties.get_instance().get_property("use_ai"))
+        except ImportError as e:
+            print(f"Error: Web mode requires Flask. Install with: pip install javacore_analyser[web]")
+            print(f"Details: {e}")
+            exit(1)
     elif app_type.lower() == "batch":
         print("Running batch application")
         javacore_analyser_batch.batch_process(args.input, args.output)

--- a/src/javacore_analyser/__main__.py
+++ b/src/javacore_analyser/__main__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import argparse
+import sys
 
 from javacore_analyser import javacore_analyser_batch, common_utils
 from javacore_analyser.properties import Properties
@@ -35,7 +36,7 @@ def main():
         except ImportError as e:
             print(f"Error: Web mode requires Flask. Install with: pip install javacore_analyser[web]")
             print(f"Details: {e}")
-            exit(1)
+            sys.exit(1)
     elif app_type.lower() == "batch":
         print("Running batch application")
         javacore_analyser_batch.batch_process(args.input, args.output)


### PR DESCRIPTION
## Description
This PR fixes the Flask import error that occurs when running batch mode without Flask installed.

Fixes #265

## Changes Made
- Removed unconditional import of `javacore_analyser_web` from module level in `__main__.py`
- Made the import conditional - only imports when web mode is requested
- Added helpful error message directing users to install Flask with: `pip install javacore_analyser[web]`

## Root Cause
The `__main__.py` file was importing `javacore_analyser_web` unconditionally at the module level, which requires Flask. However, Flask is an optional dependency in `pyproject.toml` under `[project.optional-dependencies]`.

## Impact
- Users who only need batch mode can now use the tool without installing Flask
- Reduces installation size and dependencies for batch-only users
- Maintains backward compatibility for web mode users
- Web mode users get a clear error message if Flask is not installed

## How it was tested
The issue has been visible on Ecurep. Therefore it was the only one platform where it could be tested.
Tested on Ecurep. Here is the output: https://tecurep.itc.ibm.com/rest/download/TS000000345/2026-05-12/javacores-DUP0001.zip_unpack/javacores/jazz.net_Archive%20%5B25-01-03%2011-07-56%5D.har-wait_AE_PD/index.html?fileSize=2220793