### PR TITLE
#269 Set root logger to DEBUG for wait2-debug.log

### DIFF
--- a/src/javacore_analyser/common_utils.py
+++ b/src/javacore_analyser/common_utils.py
@@ -33,11 +33,16 @@ def create_file_logging(logging_file_dir):
 
 
 def create_console_logging() -> None:
-    logging.getLogger().setLevel(logging.INFO)
+    root_logger = logging.getLogger()
+    # Remove any existing handlers (e.g., default lastResort handler)
+    root_logger.handlers.clear()
+    # Set root logger to DEBUG to allow DEBUG messages to reach file handler (added later)
+    # Console handler will filter to INFO level only
+    root_logger.setLevel(logging.DEBUG)
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(logging.INFO)
     console_handler.setFormatter(logging.Formatter(LOGGING_FORMAT))
-    logging.getLogger().addHandler(console_handler)
+    root_logger.addHandler(console_handler)
 
 
 def add_common_args(parser):

--- a/test/test_javacore_analyser.py
+++ b/test/test_javacore_analyser.py
@@ -95,7 +95,7 @@ class TestJavacoreAnalyser(unittest.TestCase):
         finally:
             sys.stdout = default_output  # Reset redirect.
   
-    def test_appriopriate_logging_level_for_file_and_console(self):
+    def test_logging_level_for_file_and_console(self):
         """Test that wait2-debug.log contains DEBUG level messages while console does not (issue #269)"""
         default_output = sys.stdout
         captured_output = io.StringIO()  # Create StringIO object

--- a/test/test_javacore_analyser.py
+++ b/test/test_javacore_analyser.py
@@ -94,6 +94,42 @@ class TestJavacoreAnalyser(unittest.TestCase):
                              "DEBUG")
         finally:
             sys.stdout = default_output  # Reset redirect.
+  
+    def test_appriopriate_logging_level_for_file_and_console(self):
+        """Test that wait2-debug.log contains DEBUG level messages while console does not (issue #269)"""
+        default_output = sys.stdout
+        captured_output = io.StringIO()  # Create StringIO object
+        sys.stdout = captured_output  # and redirect stdout.
+        try:
+            self.runMainWithParams(self.ziptestargs)
+            console_output = captured_output.getvalue()
+            
+            # Verify console output does NOT contain DEBUG messages
+            self.assertNotRegex(console_output, r'\[DEBUG\]',
+                               "Console output should NOT contain DEBUG level messages")
+            # Verify console output DOES contain INFO messages
+            self.assertRegex(console_output, r'\[INFO\]',
+                            "Console output should contain INFO level messages")
+        finally:
+            sys.stdout = default_output  # Reset redirect.
+        
+        # Read the debug log file
+        debug_log_path = "tmp/wait2-debug.log"
+        self.assertTrue(os.path.exists(debug_log_path), "wait2-debug.log should exist")
+        
+        with open(debug_log_path, 'r') as f:
+            debug_log_content = f.read()
+        
+        # Verify DEBUG messages are present in the log file
+        self.assertRegex(debug_log_content, r'\[DEBUG\]',
+                        "wait2-debug.log should contain DEBUG level messages")
+        # Verify INFO messages are also present
+        self.assertRegex(debug_log_content, r'\[INFO\]',
+                        "wait2-debug.log should contain INFO level messages")
+        # Verify the log format includes required fields
+        self.assertRegex(debug_log_content, r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}',
+                        "wait2-debug.log should include timestamp")
+
 
     def test_expat_error(self):
         os.chmod(self.expateerror[1], 0o555)


### PR DESCRIPTION
Fixes #269 

- Modified create_console_logging() to set root logger level to DEBUG
- Console handler filters messages to INFO level only
- File handler (wait2-debug.log) receives both INFO and DEBUG messages
- Cleared existing handlers to prevent default lastResort handler interference

This ensures wait2-debug.log contains DEBUG level messages while console output remains at INFO level only.