### PR TITLE
#271 Processing har fails with IndexError: list index out of range

### DIFF
--- a/src/javacore_analyser/har_file.py
+++ b/src/javacore_analyser/har_file.py
@@ -48,8 +48,19 @@ class HarFile:
         """
         har_file_node = doc.createElement("har_file")
         har_file_node.setAttribute("filename", os.path.basename(self.path))
-        har_file_node.setAttribute("hostname", str(self.har.hostname))
-        har_file_node.setAttribute("browser", str(self.har.browser))
+        
+        # Handle cases where HAR file has no valid pages or missing browser info (issue #271)
+        try:
+            hostname = str(self.har.hostname)
+        except (IndexError, AttributeError, KeyError):
+            hostname = "unknown"
+        har_file_node.setAttribute("hostname", hostname)
+        
+        try:
+            browser = str(self.har.browser)
+        except (IndexError, AttributeError, KeyError):
+            browser = "unknown"
+        har_file_node.setAttribute("browser", browser)
         for page in self.har.pages:
             for entry in page.entries:
                 http_call = HttpCall(entry)

--- a/test/data/empty_pages.har
+++ b/test/data/empty_pages.har
@@ -1,0 +1,11 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Test Creator",
+      "version": "1.0"
+    },
+    "pages": [],
+    "entries": []
+  }
+}

--- a/test/test_har_file.py
+++ b/test/test_har_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright IBM Corp. 2024 - 2025
+# Copyright IBM Corp. 2024 - 2026
 # SPDX-License-Identifier: Apache-2.0
 #
 import unittest
@@ -35,6 +35,25 @@ class TestHarFile(unittest.TestCase):
         self.assertEqual(http_call_node.attributes["size"].nodeValue, "1234")
         self.assertEqual(http_call_node.attributes["success"].nodeValue, 'False')
         self.assertEqual(http_call_node.attributes["duration"].nodeValue, "900")
+
+    def test_har_file_with_no_valid_pages(self):
+        """Test that HAR files with no valid pages are handled gracefully (issue #271)"""
+        empty_har_path = "test/data/empty_pages.har"
+        har_file = HarFile(empty_har_path)
+        element = har_file.get_xml(self.doc)
+        
+        self.assertTrue(element, "HAR file XML is None")
+        self.assertEqual(element.__class__, Element, "Wrong DOM object returned")
+        self.assertEqual(element.tagName, "har_file", "Wrong root element name")
+        
+        # Verify that hostname and browser are set to "unknown" when no valid pages exist
+        self.assertEqual(element.attributes["hostname"].nodeValue, "unknown",
+                        "Hostname should be 'unknown' for HAR with no valid pages")
+        self.assertEqual(element.attributes["browser"].nodeValue, "unknown",
+                        "Browser should be 'unknown' for HAR with no valid pages")
+        
+        # Verify no HTTP calls are present
+        self.assertEqual(len(element.childNodes), 0, "Should have no HTTP calls")
 
 
 


### PR DESCRIPTION
Fixes #271

# Summary

This pull request fixes a bug where processing HAR files with no valid pages causes an `IndexError: list index out of range`. The application now gracefully handles edge cases when processing HAR files that lack page or browser information.

# Changes Made

## Bug Fix
- Added exception handling in [`har_file.py`](src/javacore_analyser/har_file.py:51) for `IndexError`, `AttributeError`, and `KeyError` when accessing hostname and browser properties
- These exceptions occur when HAR files have no valid pages or missing browser information
- Set hostname and browser to "unknown" when exceptions occur

## Testing
- Added [`test/data/empty_pages.har`](test/data/empty_pages.har) as test fixture containing a minimal valid HAR file with empty pages
- Added unit test [`test_har_file_with_no_valid_pages()`](test/test_har_file.py:40) to verify graceful handling
- Test confirms hostname and browser are set to "unknown" and no HTTP calls are generated

# How it was tested

All unit tests pass successfully:
```bash
PYTHONPATH=src:test python -m unittest test.test_har_file
```

Output:
```
...
----------------------------------------------------------------------
Ran 3 tests in 0.038s

OK
```

The new test specifically validates:
1. HAR files with empty pages array don't crash
2. Hostname attribute is set to "unknown"
3. Browser attribute is set to "unknown"
4. No HTTP calls are present in the output