### PR TITLE
#132 Add timestamps to thread snapshots in All Threads section

### DIFF
--- a/src/javacore_analyser/data/xml/sections/all_threads.xsl
+++ b/src/javacore_analyser/data/xml/sections/all_threads.xsl
@@ -92,6 +92,7 @@
                                             <xsl:attribute name="id"><xsl:value-of select="concat('stack',$i)"/></xsl:attribute>
                                             java/lang/Thread:<xsl:value-of select="thread_address"/>
                                             <xsl:for-each select="*[starts-with(name(), 'stack')]">
+                                                    <br /><strong>Timestamp: <xsl:value-of select="timestamp"/></strong>
                                                 <div>
                                                     <xsl:choose>
                                                         <xsl:when test="stack_depth &gt; 0">


### PR DESCRIPTION
Fixes #132

## Description
This PR adds timestamps next to each thread snapshot (stack trace) when viewing the "All Threads" section in the main report page. Previously, timestamps were only visible in the individual thread drill-down pages.

## Changes
- Modified `src/javacore_analyser/data/xml/sections/all_threads.xsl` to display timestamps in bold format next to each stack trace

## How it was tested
Manual testing was performed for test data