### PR TITLE
#310 add classification to javacore details

### DIFF
--- a/src/javacore_analyser/data/style.css
+++ b/src/javacore_analyser/data/style.css
@@ -255,3 +255,26 @@ div.margined {
     background-color: #ffcccc;
     font-weight: bold;
 }
+
+/* ML classification badge colours */
+.ml-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 0.85em;
+    white-space: nowrap;
+}
+
+.ml-computing        { background-color: #cce5ff; color: #004085; }
+.ml-display-graphics { background-color: #d4edda; color: #155724; }
+.ml-java-internal    { background-color: #e2d9f3; color: #4a235a; }
+.ml-liberty-internal { background-color: #d6d6f5; color: #2c2c7a; }
+.ml-read-database    { background-color: #fff3cd; color: #856404; }
+.ml-read-disk        { background-color: #fde8c8; color: #7d4200; }
+.ml-read-network     { background-color: #fdd9b5; color: #6d3200; }
+.ml-save-disk        { background-color: #f8d7da; color: #842029; }
+.ml-wait-condition   { background-color: #f5c6cb; color: #721c24; }
+.ml-wait-connection  { background-color: #f1b0b7; color: #6f1117; }
+.ml-write-database   { background-color: #d1ecf1; color: #0c5460; }
+.ml-write-network    { background-color: #bee5eb; color: #0a4650; }
+.ml-unknown          { background-color: #e9ecef; color: #495057; }

--- a/src/javacore_analyser/data/xml/javacores/javacore.xsl
+++ b/src/javacore_analyser/data/xml/javacores/javacore.xsl
@@ -45,6 +45,11 @@
                                     <th>Memory allocated since last GC (MB)</th>
                                     <th>Java stack depth</th>
                                     <th>Status</th>
+                                    <xsl:choose>
+                                        <xsl:when test="//@use_ml='True'">
+                                            <th>Classification</th>
+                                        </xsl:when>
+                                    </xsl:choose>
                                 </tr>
                             </thead>
                             <tbody>
@@ -154,10 +159,35 @@
                                             </td>
                                         </xsl:when>
                                         <xsl:otherwise>
-                                            <td><xsl:value-of select="state"/></td>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </tr>
+                                             <td><xsl:value-of select="state"/></td>
+                                         </xsl:otherwise>
+                                     </xsl:choose>
+                                     <xsl:choose>
+                                         <xsl:when test="//@use_ml='True'">
+                                             <td>
+                                                 <xsl:variable name="cls" select="ml_classification"/>
+                                                 <span>
+                                                     <xsl:attribute name="class">ml-badge <xsl:choose>
+                                                         <xsl:when test="$cls='Computing'">ml-computing</xsl:when>
+                                                         <xsl:when test="$cls='Display Graphics'">ml-display-graphics</xsl:when>
+                                                         <xsl:when test="$cls='Java Internal'">ml-java-internal</xsl:when>
+                                                         <xsl:when test="$cls='Liberty Internal'">ml-liberty-internal</xsl:when>
+                                                         <xsl:when test="$cls='Read From Database'">ml-read-database</xsl:when>
+                                                         <xsl:when test="$cls='Read From Disk'">ml-read-disk</xsl:when>
+                                                         <xsl:when test="$cls='Read From Network'">ml-read-network</xsl:when>
+                                                         <xsl:when test="$cls='Save To Disk'">ml-save-disk</xsl:when>
+                                                         <xsl:when test="$cls='Wait For Condition'">ml-wait-condition</xsl:when>
+                                                         <xsl:when test="$cls='Wait For Connection'">ml-wait-connection</xsl:when>
+                                                         <xsl:when test="$cls='Write To Database'">ml-write-database</xsl:when>
+                                                         <xsl:when test="$cls='Write To Network'">ml-write-network</xsl:when>
+                                                         <xsl:otherwise>ml-unknown</xsl:otherwise>
+                                                     </xsl:choose></xsl:attribute>
+                                                     <xsl:value-of select="$cls"/>
+                                                 </span>
+                                             </td>
+                                         </xsl:when>
+                                     </xsl:choose>
+                                 </tr>
                             </xsl:for-each>
                             </tbody>
                         </table>

--- a/src/javacore_analyser/data/xml/sections/all_threads.xsl
+++ b/src/javacore_analyser/data/xml/sections/all_threads.xsl
@@ -228,7 +228,24 @@
                                             <xsl:when test="count(ml_classification/classification_entry) = 0">N/A</xsl:when>
                                             <xsl:otherwise>
                                                 <xsl:for-each select="ml_classification/classification_entry">
-                                                    <xsl:value-of select="@value" /> (<xsl:value-of select="@occurrences" />)<xsl:if test="position() != last()"><br/></xsl:if>
+                                                    <span class="ml-badge">
+                                                        <xsl:attribute name="class">ml-badge <xsl:choose>
+                                                            <xsl:when test="@value='Computing'">ml-computing</xsl:when>
+                                                            <xsl:when test="@value='Display Graphics'">ml-display-graphics</xsl:when>
+                                                            <xsl:when test="@value='Java Internal'">ml-java-internal</xsl:when>
+                                                            <xsl:when test="@value='Liberty Internal'">ml-liberty-internal</xsl:when>
+                                                            <xsl:when test="@value='Read From Database'">ml-read-database</xsl:when>
+                                                            <xsl:when test="@value='Read From Disk'">ml-read-disk</xsl:when>
+                                                            <xsl:when test="@value='Read From Network'">ml-read-network</xsl:when>
+                                                            <xsl:when test="@value='Save To Disk'">ml-save-disk</xsl:when>
+                                                            <xsl:when test="@value='Wait For Condition'">ml-wait-condition</xsl:when>
+                                                            <xsl:when test="@value='Wait For Connection'">ml-wait-connection</xsl:when>
+                                                            <xsl:when test="@value='Write To Database'">ml-write-database</xsl:when>
+                                                            <xsl:when test="@value='Write To Network'">ml-write-network</xsl:when>
+                                                            <xsl:otherwise>ml-unknown</xsl:otherwise>
+                                                        </xsl:choose></xsl:attribute>
+                                                        <xsl:value-of select="@value" /> (<xsl:value-of select="@occurrences" />)
+                                                    </span><xsl:if test="position() != last()"><br/></xsl:if>
                                                 </xsl:for-each>
                                             </xsl:otherwise>
                                         </xsl:choose>

--- a/src/javacore_analyser/data/xml/sections/all_threads.xsl
+++ b/src/javacore_analyser/data/xml/sections/all_threads.xsl
@@ -223,13 +223,12 @@
                             <xsl:choose>
                                 <xsl:when test="//@use_ml='True'">
                                     <td>
-                                        <!-- Display classification as 'category: count;' pairs, sorted by occurrence count -->
+                                        <!-- Display classification as 'Category (count)' entries, sorted by occurrence count -->
                                         <xsl:choose>
                                             <xsl:when test="count(ml_classification/classification_entry) = 0">N/A</xsl:when>
                                             <xsl:otherwise>
                                                 <xsl:for-each select="ml_classification/classification_entry">
-                                                    <xsl:value-of select="@value" />:
-                                                    <xsl:value-of select="@occurrences" />;
+                                                    <xsl:value-of select="@value" /> (<xsl:value-of select="@occurrences" />)<xsl:if test="position() != last()"><br/></xsl:if>
                                                 </xsl:for-each>
                                             </xsl:otherwise>
                                         </xsl:choose>

--- a/src/javacore_analyser/data/xml/threads/thread.xsl
+++ b/src/javacore_analyser/data/xml/threads/thread.xsl
@@ -209,7 +209,27 @@
                                     </td>
                                     <xsl:choose>
                                         <xsl:when test="//@use_ml='True'">
-                                            <td><xsl:value-of select="ml_classification"/></td>
+                                            <td>
+                                                <xsl:variable name="cls" select="ml_classification"/>
+                                                <span>
+                                                    <xsl:attribute name="class">ml-badge <xsl:choose>
+                                                        <xsl:when test="$cls='Computing'">ml-computing</xsl:when>
+                                                        <xsl:when test="$cls='Display Graphics'">ml-display-graphics</xsl:when>
+                                                        <xsl:when test="$cls='Java Internal'">ml-java-internal</xsl:when>
+                                                        <xsl:when test="$cls='Liberty Internal'">ml-liberty-internal</xsl:when>
+                                                        <xsl:when test="$cls='Read From Database'">ml-read-database</xsl:when>
+                                                        <xsl:when test="$cls='Read From Disk'">ml-read-disk</xsl:when>
+                                                        <xsl:when test="$cls='Read From Network'">ml-read-network</xsl:when>
+                                                        <xsl:when test="$cls='Save To Disk'">ml-save-disk</xsl:when>
+                                                        <xsl:when test="$cls='Wait For Condition'">ml-wait-condition</xsl:when>
+                                                        <xsl:when test="$cls='Wait For Connection'">ml-wait-connection</xsl:when>
+                                                        <xsl:when test="$cls='Write To Database'">ml-write-database</xsl:when>
+                                                        <xsl:when test="$cls='Write To Network'">ml-write-network</xsl:when>
+                                                        <xsl:otherwise>ml-unknown</xsl:otherwise>
+                                                    </xsl:choose></xsl:attribute>
+                                                    <xsl:value-of select="$cls"/>
+                                                </span>
+                                            </td>
                                         </xsl:when>
                                     </xsl:choose>
                                 </tr>

--- a/src/javacore_analyser/ml/javacoreThreadsClassifierLabelEncoderMapping.json
+++ b/src/javacore_analyser/ml/javacoreThreadsClassifierLabelEncoderMapping.json
@@ -1,1 +1,1 @@
-["computing", "display grahics", "java internal", "liberty internal", "read from database", "read from disk", "read from network", "save to disk", "wait for condition", "wait for connection", "write to database", "write to network", NaN]
+["Computing", "Display Graphics", "Java Internal", "Liberty Internal", "Read From Database", "Read From Disk", "Read From Network", "Save To Disk", "Wait For Condition", "Wait For Connection", "Write To Database", "Write To Network", NaN]

--- a/test/test_javacore_classifier.py
+++ b/test/test_javacore_classifier.py
@@ -73,6 +73,12 @@ class TestJavacoreClassifier(unittest.TestCase):
         self.assertIsInstance(result, str)
         self.assertGreater(len(result), 0)
 
+    def test_predict_returns_title_case_label(self):
+        """predict() should return a Title Case classification label (Fixes #308)."""
+        result = self._predict()
+        # Each word of the label should start with an uppercase letter
+        self.assertEqual(result, result.title(), f"Expected Title Case label, got: {result!r}")
+
     # ------------------------------------------------------------------
     # Performance test  (Fixes #305)
     # ------------------------------------------------------------------


### PR DESCRIPTION
# Summary

Fixes #310. Fixes #308.

This pull request improves the visual presentation of ML thread classification labels across the HTML report output. Classification labels are now displayed as styled, colour-coded badges instead of plain text. Additionally, the label encoder mapping has been corrected to use proper Title Case values (fixing a typo — `"display grahics"` → `"Display Graphics"` — and normalising casing throughout), and a new test verifies that predicted labels are always returned in Title Case.

# Files Changed

📄 `src/javacore_analyser/data/xml/javacores/javacore.xsl`

Updates the per-javacore thread table to conditionally render a **"Classification"** column header (when `use_ml='True'`) and renders each thread's `ml_classification` value as a colour-coded `.ml-badge` span by mapping the classification string to its corresponding CSS modifier class via `xsl:choose`.

The remaining changes below are from branch `issue-308-improve-classification-lookup-display` (PR #309 )

📄 `src/javacore_analyser/data/style.css`

📄 `src/javacore_analyser/data/xml/sections/all_threads.xsl`

📄 `src/javacore_analyser/data/xml/threads/thread.xsl`

📄 `src/javacore_analyser/ml/javacoreThreadsClassifierLabelEncoderMapping.json`

📄 `test/test_javacore_classifier.py`