### PR TITLE
#312 thread classification chart

### DIFF
--- a/src/javacore_analyser/data/jquery/wait2scripts.js
+++ b/src/javacore_analyser/data/jquery/wait2scripts.js
@@ -534,3 +534,133 @@ const loadChart = function () {
     },
   });
 };
+
+// Distinct colours for up to 13 classification categories (12 named + unknown).
+const CLASSIFICATION_COLOURS = [
+  'rgba(255,99,132,1)',
+  'rgba(54,162,235,1)',
+  'rgba(75,192,192,1)',
+  'rgba(255,159,64,1)',
+  'rgba(153,102,255,1)',
+  'rgba(46,139,87,1)',
+  'rgba(255,205,86,1)',
+  'rgba(205,92,92,1)',
+  'rgba(0,128,128,1)',
+  'rgba(128,0,128,1)',
+  'rgba(0,0,205,1)',
+  'rgba(210,105,30,1)',
+  'rgba(128,128,128,1)',
+];
+
+/**
+ * loadChartThreadClassifications – reads per-javacore classification counts
+ * from the hidden table emitted by system_resources.xsl and renders a
+ * multi-line Chart.js chart: X axis = javacore timestamp, Y axis = number of
+ * thread snapshots, one line per classification category.
+ */
+const loadChartThreadClassifications = function() {
+
+  const ctx = document.getElementById('myChartThreadClassifications');
+  if (!ctx) return;
+
+  // The hidden data table has one row per javacore; each row contains:
+  //   cells[0] = ISO timestamp, cells[1..] = counts for each category
+  // The header row (index 0) contains category names in cells[1..].
+  const dataTable = document.getElementById('thread_classifications_data_table');
+  if (!dataTable || dataTable.rows.length < 2) {
+    console.log('thread_classifications_data_table not found or empty');
+    return;
+  }
+
+  const headerRow = dataTable.rows[0];
+  // Collect category names from header columns (skip column 0 = "timestamp")
+  const categories = [];
+  for (let c = 1; c < headerRow.cells.length; c++) {
+    categories.push(headerRow.cells[c].innerHTML.trim());
+  }
+
+  if (categories.length === 0) {
+    console.log('No classification categories found in data table');
+    return;
+  }
+
+  const labels = [];
+  // One array of counts per category
+  const seriesData = categories.map(() => []);
+
+  for (let r = 1; r < dataTable.rows.length; r++) {
+    const row = dataTable.rows[r];
+    labels.push(new Date(row.cells[0].innerHTML.trim()).valueOf());
+    for (let c = 0; c < categories.length; c++) {
+      seriesData[c].push(Number(row.cells[c + 1].innerHTML.trim()) || 0);
+    }
+  }
+
+  const datasets = categories.map(function(cat, idx) {
+    const colour = CLASSIFICATION_COLOURS[idx % CLASSIFICATION_COLOURS.length];
+    return {
+      label: cat,
+      data: seriesData[idx],
+      borderColor: colour,
+      backgroundColor: colour.replace(',1)', ',0.15)'),
+      borderWidth: 2,
+      pointRadius: 3,
+      fill: false,
+    };
+  });
+
+  new Chart(ctx, {
+    type: 'line',
+    responsive: true,
+    data: {
+      labels: labels,
+      datasets: datasets,
+    },
+    options: {
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: {
+            display: true,
+            text: 'Number of threads'
+          }
+        },
+        x: {
+          type: 'time',
+          time: {
+            displayFormats: {
+              millisecond: 'HH:mm:ss.SSS',
+              second: 'HH:mm:ss',
+              minute: 'HH:mm',
+              hour: 'MMM dd HH:mm',
+              day: 'MMM dd',
+              week: 'MMM dd',
+              month: 'MMM yyyy',
+              quarter: 'MMM yyyy',
+              year: 'yyyy'
+            }
+          }
+        }
+      },
+      plugins: {
+        zoom: {
+          zoom: {
+            wheel: { enabled: true },
+            pinch: { enabled: true },
+            mode: 'xy',
+          },
+          pan: {
+            enabled: true,
+            mode: 'xy',
+          },
+          limits: {
+            x: { min: 'original', max: 'original' },
+            y: { min: 'original', max: 'original' }
+          }
+        }
+      }
+    },
+  });
+
+  console.log('Thread classifications chart created successfully');
+};

--- a/src/javacore_analyser/data/xml/report.xsl
+++ b/src/javacore_analyser/data/xml/report.xsl
@@ -31,7 +31,7 @@
             <body id="doc_body">
                 <xsl:call-template name="body_content"/>
             </body>
-            <script>loadChartGC();loadChartCPUUsage();</script>
+            <script>loadChartGC();loadChartCPUUsage();loadChartThreadClassifications();</script>
             <script type="text/javascript" src="data/expand.js"> _ <!-- underscore character is required to prevent converting to <script /> which does not work --> </script>
         </html>
         <xsl:call-template name="expand_it"/>

--- a/src/javacore_analyser/data/xml/sections/system_resources.xsl
+++ b/src/javacore_analyser/data/xml/sections/system_resources.xsl
@@ -7,6 +7,12 @@
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+    <!-- Key used for Muenchian grouping to find distinct classification labels
+         across all javacore_classifications/classification_entry nodes. -->
+    <xsl:key name="classification-by-value"
+             match="doc/report_info/javacore_list/javacore/javacore_classifications/classification_entry"
+             use="@value"/>
+
     <xsl:template name="system_resources">
         <h3 id="system_resource_utilization_h3"><a id="toggleresourcesutil" href="javascript:expand_it(systemresources,toggleresourcesutil)" class="expandit">System resources utilization</a></h3>
         <div id="systemresources"  style="display:none;">
@@ -117,12 +123,9 @@
                         <thead>
                             <tr>
                                 <th>timestamp</th>
-                                <!-- Emit one header cell per distinct classification label found across all javacores. -->
-                                <xsl:for-each select="doc/report_info/javacore_list/javacore[1]/javacore_classifications/classification_entry">
-                                    <th><xsl:value-of select="@value"/></th>
-                                </xsl:for-each>
-                                <!-- Pick up any additional categories that may appear only in later javacores. -->
-                                <xsl:for-each select="doc/report_info/javacore_list/javacore[position() &gt; 1]/javacore_classifications/classification_entry[not(@value = //javacore_list/javacore[1]/javacore_classifications/classification_entry/@value)]">
+                                <!-- Muenchian grouping: emit exactly one header cell per distinct
+                                     classification label found across ALL javacore nodes. -->
+                                <xsl:for-each select="doc/report_info/javacore_list/javacore/javacore_classifications/classification_entry[generate-id() = generate-id(key('classification-by-value', @value)[1])]">
                                     <th><xsl:value-of select="@value"/></th>
                                 </xsl:for-each>
                             </tr>
@@ -132,19 +135,8 @@
                                 <xsl:variable name="jc" select="."/>
                                 <tr>
                                     <td><xsl:value-of select="javacore_file_time_stamp"/></td>
-                                    <!-- For every category known from the first javacore, output the count (0 if absent). -->
-                                    <xsl:for-each select="//javacore_list/javacore[1]/javacore_classifications/classification_entry">
-                                        <xsl:variable name="cat" select="@value"/>
-                                        <xsl:variable name="entry" select="$jc/javacore_classifications/classification_entry[@value=$cat]"/>
-                                        <td>
-                                            <xsl:choose>
-                                                <xsl:when test="$entry"><xsl:value-of select="$entry/@count"/></xsl:when>
-                                                <xsl:otherwise>0</xsl:otherwise>
-                                            </xsl:choose>
-                                        </td>
-                                    </xsl:for-each>
-                                    <!-- Extra categories that first appeared after javacore 1. -->
-                                    <xsl:for-each select="//javacore_list/javacore[position() &gt; 1]/javacore_classifications/classification_entry[not(@value = //javacore_list/javacore[1]/javacore_classifications/classification_entry/@value)]">
+                                    <!-- One cell per distinct category; look up this javacore's count (0 if absent). -->
+                                    <xsl:for-each select="//javacore_list/javacore/javacore_classifications/classification_entry[generate-id() = generate-id(key('classification-by-value', @value)[1])]">
                                         <xsl:variable name="cat" select="@value"/>
                                         <xsl:variable name="entry" select="$jc/javacore_classifications/classification_entry[@value=$cat]"/>
                                         <td>

--- a/src/javacore_analyser/data/xml/sections/system_resources.xsl
+++ b/src/javacore_analyser/data/xml/sections/system_resources.xsl
@@ -92,6 +92,74 @@
                     No verbosegc logs were provided, so verbose GC data cannot be shown.
                 </xsl:otherwise>
             </xsl:choose>
+
+            <!-- Thread Classification Over Time chart – only shown when ML is enabled
+                 and at least two javacores are present so there is a time dimension. -->
+            <xsl:if test="//@use_ml='True' and //javacore_count &gt; 1">
+                <h4>Thread Classification Over Time</h4>
+                <a id="toggleclassificationdoc" href="javascript:expand_it(classificationdoc,toggleclassificationdoc)" class="expandit">
+                    What does this chart tell me?</a>
+                <div id="classificationdoc" style="display:none;">
+                    This chart shows how the number of thread snapshots belonging to each
+                    machine-learning classification category changes over time.
+                    The X axis represents the javacore generation time and the Y axis shows
+                    the number of thread snapshots with that classification in each javacore.
+                    Each line corresponds to one classification category.
+                </div>
+                <div class="chart-container" style="overflow-x:auto;">
+                    <canvas id="myChartThreadClassifications" height="200" width="1400"></canvas>
+                </div>
+                <!-- Hidden data table consumed by loadChartThreadClassifications() in wait2scripts.js.
+                     Row 0 = header (timestamp + one cell per category).
+                     Rows 1..N = one row per javacore: ISO timestamp + counts per category. -->
+                <div style="display:none;">
+                    <table id="thread_classifications_data_table">
+                        <thead>
+                            <tr>
+                                <th>timestamp</th>
+                                <!-- Emit one header cell per distinct classification label found across all javacores. -->
+                                <xsl:for-each select="doc/report_info/javacore_list/javacore[1]/javacore_classifications/classification_entry">
+                                    <th><xsl:value-of select="@value"/></th>
+                                </xsl:for-each>
+                                <!-- Pick up any additional categories that may appear only in later javacores. -->
+                                <xsl:for-each select="doc/report_info/javacore_list/javacore[position() &gt; 1]/javacore_classifications/classification_entry[not(@value = //javacore_list/javacore[1]/javacore_classifications/classification_entry/@value)]">
+                                    <th><xsl:value-of select="@value"/></th>
+                                </xsl:for-each>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <xsl:for-each select="doc/report_info/javacore_list/javacore">
+                                <xsl:variable name="jc" select="."/>
+                                <tr>
+                                    <td><xsl:value-of select="javacore_file_time_stamp"/></td>
+                                    <!-- For every category known from the first javacore, output the count (0 if absent). -->
+                                    <xsl:for-each select="//javacore_list/javacore[1]/javacore_classifications/classification_entry">
+                                        <xsl:variable name="cat" select="@value"/>
+                                        <xsl:variable name="entry" select="$jc/javacore_classifications/classification_entry[@value=$cat]"/>
+                                        <td>
+                                            <xsl:choose>
+                                                <xsl:when test="$entry"><xsl:value-of select="$entry/@count"/></xsl:when>
+                                                <xsl:otherwise>0</xsl:otherwise>
+                                            </xsl:choose>
+                                        </td>
+                                    </xsl:for-each>
+                                    <!-- Extra categories that first appeared after javacore 1. -->
+                                    <xsl:for-each select="//javacore_list/javacore[position() &gt; 1]/javacore_classifications/classification_entry[not(@value = //javacore_list/javacore[1]/javacore_classifications/classification_entry/@value)]">
+                                        <xsl:variable name="cat" select="@value"/>
+                                        <xsl:variable name="entry" select="$jc/javacore_classifications/classification_entry[@value=$cat]"/>
+                                        <td>
+                                            <xsl:choose>
+                                                <xsl:when test="$entry"><xsl:value-of select="$entry/@count"/></xsl:when>
+                                                <xsl:otherwise>0</xsl:otherwise>
+                                            </xsl:choose>
+                                        </td>
+                                    </xsl:for-each>
+                                </tr>
+                            </xsl:for-each>
+                        </tbody>
+                    </table>
+                </div>
+            </xsl:if>
         </div>
     </xsl:template>
 

--- a/src/javacore_analyser/javacore_set.py
+++ b/src/javacore_analyser/javacore_set.py
@@ -603,6 +603,23 @@ class JavacoreSet:
                 javacore_load_node = self.doc.createElement("javacore_load")
                 javacore_node.appendChild(javacore_load_node)
                 javacore_load_node.appendChild(self.doc.createTextNode(str(jc.get_load())))
+                # When ML classification is enabled, count how many thread snapshots in
+                # this javacore received each classification label.  The counts are
+                # stored as <classification_entry value="…" count="…"/> children so the
+                # thread-classification-over-time chart can read them per javacore.
+                if self.use_ml:
+                    classification_counts = {}
+                    for snapshot in jc.snapshots:
+                        label = snapshot.get_classification()
+                        if label:
+                            classification_counts[label] = classification_counts.get(label, 0) + 1
+                    jc_classifications_node = self.doc.createElement("javacore_classifications")
+                    javacore_node.appendChild(jc_classifications_node)
+                    for label, count in classification_counts.items():
+                        entry_node = self.doc.createElement("classification_entry")
+                        entry_node.setAttribute("value", label)
+                        entry_node.setAttribute("count", str(count))
+                        jc_classifications_node.appendChild(entry_node)
 
         verbose_gc_list_node = self.doc.createElement("verbose_gc_list")
         report_info_node.appendChild(verbose_gc_list_node)


### PR DESCRIPTION
# Summary

Fixes #312 . This PR contains also the changes from #308 and #310.

This pull request improves the ML thread classification feature by standardising classification labels to Title Case, adding colour-coded badges for classification categories across all report views, and introducing a new "Thread Classification Over Time" chart in the system resources section. It also fixes a typo in the label encoder mapping ("display grahics" → "Display Graphics") and adds a unit test to enforce the Title Case label format. The label standardisation, badge styling, and related UI changes are part of issue #308; the changes described below reflect the most recent commit.

# Files Changed

📄 `src/javacore_analyser/data/jquery/wait2scripts.js`

Adds a new `loadChartThreadClassifications()` function that reads per-javacore classification counts from a hidden HTML data table and renders a multi-line Chart.js time-series chart. Each line represents one ML classification category, plotted over javacore timestamps on the X axis and thread snapshot counts on the Y axis. Also defines a `CLASSIFICATION_COLOURS` constant array with 13 distinct colours (one per category). The chart supports zoom and pan interactions consistent with the existing charts.

📄 `src/javacore_analyser/data/xml/sections/system_resources.xsl`

Adds a new "Thread Classification Over Time" section to the system resources page, shown only when ML is enabled and more than one javacore is present. Includes an expandable description, a `<canvas>` element for the chart, and a hidden data table that encodes per-javacore classification counts for consumption by `loadChartThreadClassifications()` in JavaScript.

📄 `src/javacore_analyser/javacore_set.py`

Adds logic to the javacore XML report builder to aggregate per-javacore ML classification counts when `use_ml` is enabled. For each javacore, it iterates over its thread snapshots, counts occurrences of each classification label, and emits `<javacore_classifications>` / `<classification_entry value="…" count="…"/>` XML nodes, which are consumed by the new chart in `system_resources.xsl`.

---

The following files were changed as part of issue #308:

📄 `src/javacore_analyser/data/style.css`

Adds CSS styles for ML classification badges. Introduces a base `.ml-badge` class for inline pill-style display, and 13 category-specific colour classes (e.g., `.ml-computing`, `.ml-wait-condition`, `.ml-unknown`) with distinct background and text colour combinations to visually distinguish each classification label.

📄 `src/javacore_analyser/data/xml/javacores/javacore.xsl`

Updates the per-javacore thread table to conditionally render a "Classification" column header and a colour-coded badge cell for each thread snapshot when ML is enabled (`use_ml='True'`). The badge class is determined by mapping the `ml_classification` value to the corresponding CSS class from `style.css`.

📄 `src/javacore_analyser/data/xml/report.xsl`

Adds a call to `loadChartThreadClassifications()` in the inline script block so the new classification chart is initialised when the report page loads.

📄 `src/javacore_analyser/data/xml/sections/all_threads.xsl`

Updates the classification display in the all-threads table to use colour-coded `ml-badge` spans instead of plain `category: count;` text. Each classification entry is now rendered as a styled badge with the count in parentheses (e.g., `Computing (5)`), separated by line breaks.

📄 `src/javacore_analyser/data/xml/threads/thread.xsl`

Updates the per-thread snapshot table to render ML classification labels as colour-coded `ml-badge` spans instead of plain text, consistent with the badge styling applied in the other XSL templates.

📄 `src/javacore_analyser/ml/javacoreThreadsClassifierLabelEncoderMapping.json`

Fixes classification label formatting: all labels are updated from lowercase to Title Case (e.g., `"computing"` → `"Computing"`, `"display grahics"` → `"Display Graphics"` — also correcting a pre-existing typo). This ensures labels rendered in the UI match the CSS class mappings in the XSL templates.

📄 `test/test_javacore_classifier.py`

Adds a new unit test `test_predict_returns_title_case_label` that asserts the classifier's `predict()` method returns a Title Case string, enforcing the label format standardisation introduced in this PR (referenced as fix for issue #308).