### PR TITLE
#314 Add numpy and xgboost to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dependencies = [
     "importlib-resources",
     "tqdm",
     "haralyzer",
+    "numpy",
+    "xgboost",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Summary

Fixes #314

Added `numpy` and `xgboost` as core project dependencies in [`pyproject.toml`](pyproject.toml). These packages are now listed under `[project.dependencies]`, making them required installations for all users of the package.

# Files Changed

- **`pyproject.toml`** — Added `numpy` and `xgboost` to the `dependencies` list under `[project]`.

# Testing

Verified the changes by installing the package in a clean environment, confirming that `numpy` and `xgboost` are installed as part of the core dependencies, and running javacore-analyser to ensure it completes without errors:

```bash
# Create and activate a clean virtual environment
python -m venv .venv
source .venv/bin/activate

# Install the package
pip install .

# Verify that numpy and xgboost are installed
pip show numpy xgboost

# Run javacore-analyser and confirm it does not fail
javacore-analyser <input_file> <output_dir>
```