### PR TITLE
#317 detect permanently blocked threads

### DIFF
--- a/src/javacore_analyser/ai/performance_recommendations_prompter.py
+++ b/src/javacore_analyser/ai/performance_recommendations_prompter.py
@@ -53,7 +53,10 @@ class PerformanceRecommendationsPrompter(Prompter):
         
         # Get shutdown status
         shutdown_status: str = self._get_shutdown_status()
-        
+
+        # Get permanently blocked threads
+        permanently_blocked_threads: str = self._get_permanently_blocked_threads()
+
         # Load the prompt template from file
         template: str = self._load_prompt_template('performance_recommendations_prompt.txt')
         
@@ -67,7 +70,8 @@ class PerformanceRecommendationsPrompter(Prompter):
             gc_cpu_usage=gc_cpu_usage,
             gc_pause_times=gc_pause_times,
             main_thread_stack=main_thread_stack,
-            shutdown_status=shutdown_status
+            shutdown_status=shutdown_status,
+            permanently_blocked_threads=permanently_blocked_threads
         )
 
         return prompt
@@ -334,6 +338,30 @@ class PerformanceRecommendationsPrompter(Prompter):
             stack_lines.append(f"  at {element.get_line().strip() if element.get_line() else 'Unknown'}")
         
         return "\n".join(stack_lines) if stack_lines else "Empty stack trace"
+
+    def _get_permanently_blocked_threads(self):
+        """
+        Collects threads that are in blocked state (B) across all their snapshots,
+        indicating they never made progress and may be deadlocked or permanently starved.
+
+        Returns:
+            str: Formatted list of permanently blocked threads, or a message if none found
+        """
+        if not self.javacore_set.threads or not self.javacore_set.threads.snapshot_collections:
+            return "No thread data available"
+
+        from javacore_analyser.tips import PermanentlyBlockedThreadsTip
+        min_snapshots = PermanentlyBlockedThreadsTip.MIN_SNAPSHOTS
+
+        stuck = []
+        for thread in self.javacore_set.threads.snapshot_collections:
+            snapshots = thread.thread_snapshots
+            if len(snapshots) < min_snapshots:
+                continue
+            if all(s.state == "B" for s in snapshots):
+                stuck.append(f"{thread.name} (ID: {thread.id}): blocked in all {len(snapshots)} snapshots")
+
+        return "\n".join(stuck) if stuck else "No permanently blocked threads detected"
 
     def _get_shutdown_status(self):
         """

--- a/src/javacore_analyser/ai/tips_prompter.py
+++ b/src/javacore_analyser/ai/tips_prompter.py
@@ -13,6 +13,11 @@ class TipsPrompter(Prompter) :
         if len(self.javacore_set.tips) > 0:
             prompt = "Analyse the tips to help identify performance bottlenecks in a Java application: \n"
             for tip in self.javacore_set.tips:
-                    prompt += tip + "\n"
-            prompt += "Provide maximum of 5 suggestions for performance improvements."
+                prompt += tip + "\n"
+            prompt += (
+                "Provide maximum of 5 suggestions for performance improvements. "
+                "If any tip reports a thread blocked in all snapshots (permanently blocked), "
+                "treat this as a potential deadlock or starvation and recommend investigating "
+                "the lock that thread is waiting for."
+            )
         return prompt

--- a/src/javacore_analyser/data/prompts/performance_recommendations_prompt.txt
+++ b/src/javacore_analyser/data/prompts/performance_recommendations_prompt.txt
@@ -30,6 +30,9 @@ Main Thread Stack Trace:
 Server Shutdown Status:
 {shutdown_status}
 
+Permanently Blocked Threads (blocked in every snapshot, never made progress):
+{permanently_blocked_threads}
+
 Task:
 Identify concrete performance bottlenecks visible in the provided data and provide up to 5 specific
 recommendations to improve performance.
@@ -45,6 +48,10 @@ Requirements:
 - If the Server Shutdown Status indicates the application is shutting down (System.exit detected),
   this MUST be flagged as CRITICAL priority as it indicates the JVM is terminating.
 - Do NOT report on Server Shutdown Status if it indicates "ok" or normal operation.
+- If any permanently blocked threads are listed, flag this as a HIGH or CRITICAL issue indicating
+  a likely deadlock or permanent starvation; recommend investigating the lock each thread is
+  waiting for and cross-referencing with the top blocking threads.
+- Do NOT report on permanently blocked threads if none are listed.
 - If the provided data does not support any concrete recommendation, reply exactly:
   No evidence-based performance recommendations can be made from the provided data.
 - Display the recommendations in a clear, concise format.

--- a/src/javacore_analyser/tips.py
+++ b/src/javacore_analyser/tips.py
@@ -10,7 +10,7 @@ import logging
 # List of the tips on which run the tool
 TIPS_LIST = ["DifferentIssuesTip", "ExcludedJavacoresTip", "InvalidAccumulatedCpuTimeTip", "TooFewJavacoresTip",
              "OOMEGenerationTip", "BlockingThreadsTip", "HighCpuUsageTip", "LongGcPauseTip",
-             "SystemExitInMainThreadTip"]
+             "SystemExitInMainThreadTip", "PermanentlyBlockedThreadsTip"]
 
 
 class TestTip:
@@ -264,6 +264,40 @@ class LongGcPauseTip:
             return [msg]
         
         return []  # No long pauses detected
+
+
+class PermanentlyBlockedThreadsTip:
+    # Detects threads that are in blocked state (B) across every javacore snapshot.
+    # A thread blocked 100% of the time never makes progress and is a strong indicator
+    # of a deadlock or permanent starvation.
+
+    # Minimum number of javacores a thread must appear in before it is considered
+    MIN_SNAPSHOTS = 3
+
+    PERMANENTLY_BLOCKED_TEXT = (
+        """[WARNING] Thread "{0}" is in blocked state (B) in all {1} javacores it appears in. """
+        """This thread never made progress and may be deadlocked or permanently starved. """
+        """Check what lock it is waiting for."""
+    )
+
+    MAX_TIPS = 5
+
+    @staticmethod
+    def generate(javacore_set):
+        result = []
+        for thread in javacore_set.threads.snapshot_collections:
+            snapshots = thread.thread_snapshots
+            if len(snapshots) < PermanentlyBlockedThreadsTip.MIN_SNAPSHOTS:
+                continue
+            if all(s.state == "B" for s in snapshots):
+                result.append(
+                    PermanentlyBlockedThreadsTip.PERMANENTLY_BLOCKED_TEXT.format(
+                        thread.name, len(snapshots)
+                    )
+                )
+                if len(result) >= PermanentlyBlockedThreadsTip.MAX_TIPS:
+                    break
+        return result
 
 
 class SystemExitInMainThreadTip:

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -351,3 +351,98 @@ class TestTips(unittest.TestCase):
         self.assertIn("System.exit", result[0], "Tip should mention System.exit")
         self.assertIn("Worker-Thread-1", result[0], "Tip should mention the worker thread name")
         self.assertIn("test_javacore.txt", result[0], "Tip should mention the javacore filename")
+
+    def _make_thread(self, name, thread_id, states):
+        """Helper: build a Thread with one ThreadSnapshot per state string."""
+        thread = Thread()
+        thread.name = name
+        thread.id = thread_id
+        for state in states:
+            s = ThreadSnapshot()
+            s.state = state
+            s.cpu_usage = 0
+            thread.thread_snapshots.append(s)
+        return thread
+
+    # ------------------------------------------------------------------
+    # PermanentlyBlockedThreadsTip
+    # ------------------------------------------------------------------
+
+    def test_PermanentlyBlockedThreadsTip_no_threads(self):
+        """Returns empty list when javacore_set has no threads."""
+        javacore_set = JavacoreSet("")
+        result = tips.PermanentlyBlockedThreadsTip.generate(javacore_set)
+        self.assertEqual([], result, "Should return empty list when no threads present")
+
+    def test_PermanentlyBlockedThreadsTip_no_blocked_threads(self):
+        """Returns empty list when all threads are running (state R)."""
+        javacore_set = JavacoreSet("")
+        javacore_set.threads.snapshot_collections.append(
+            self._make_thread("worker-1", "0x1", ["R", "R", "R"])
+        )
+        javacore_set.threads.snapshot_collections.append(
+            self._make_thread("worker-2", "0x2", ["R", "CW", "R"])
+        )
+        result = tips.PermanentlyBlockedThreadsTip.generate(javacore_set)
+        self.assertEqual([], result, "Should return empty list when no thread is permanently blocked")
+
+    def test_PermanentlyBlockedThreadsTip_one_blocked_thread(self):
+        """Returns one warning when exactly one thread is blocked in all snapshots."""
+        javacore_set = JavacoreSet("")
+        javacore_set.threads.snapshot_collections.append(
+            self._make_thread("stuck-thread", "0x10", ["B", "B", "B"])
+        )
+        javacore_set.threads.snapshot_collections.append(
+            self._make_thread("healthy-thread", "0x11", ["R", "R", "R"])
+        )
+        result = tips.PermanentlyBlockedThreadsTip.generate(javacore_set)
+        self.assertEqual(1, len(result), "Should return one warning for one permanently blocked thread")
+        self.assertIn("[WARNING]", result[0], "Tip should contain WARNING")
+        self.assertIn("stuck-thread", result[0], "Tip should contain the thread name")
+        self.assertIn("3", result[0], "Tip should mention the number of snapshots")
+
+    def test_PermanentlyBlockedThreadsTip_partially_blocked_thread(self):
+        """Returns empty list when a thread is blocked in some but not all snapshots."""
+        javacore_set = JavacoreSet("")
+        javacore_set.threads.snapshot_collections.append(
+            self._make_thread("sometimes-blocked", "0x20", ["B", "B", "R"])
+        )
+        result = tips.PermanentlyBlockedThreadsTip.generate(javacore_set)
+        self.assertEqual([], result, "Should not flag a thread that is only sometimes blocked")
+
+    def test_PermanentlyBlockedThreadsTip_below_min_snapshots(self):
+        """Returns empty list when thread appears in fewer snapshots than MIN_SNAPSHOTS."""
+        javacore_set = JavacoreSet("")
+        min_snaps = tips.PermanentlyBlockedThreadsTip.MIN_SNAPSHOTS
+        # Build a thread with one fewer snapshot than the minimum
+        states = ["B"] * (min_snaps - 1)
+        javacore_set.threads.snapshot_collections.append(
+            self._make_thread("short-lived-blocked", "0x30", states)
+        )
+        result = tips.PermanentlyBlockedThreadsTip.generate(javacore_set)
+        self.assertEqual([], result,
+                         "Should not flag a thread with fewer snapshots than MIN_SNAPSHOTS")
+
+    def test_PermanentlyBlockedThreadsTip_multiple_blocked_threads(self):
+        """Returns one warning per permanently blocked thread."""
+        javacore_set = JavacoreSet("")
+        for i in range(3):
+            javacore_set.threads.snapshot_collections.append(
+                self._make_thread(f"stuck-{i}", f"0x{i}", ["B", "B", "B", "B"])
+            )
+        result = tips.PermanentlyBlockedThreadsTip.generate(javacore_set)
+        self.assertEqual(3, len(result), "Should return one warning per permanently blocked thread")
+        for tip_text in result:
+            self.assertIn("[WARNING]", tip_text)
+
+    def test_PermanentlyBlockedThreadsTip_capped_at_max(self):
+        """Never returns more warnings than MAX_TIPS."""
+        javacore_set = JavacoreSet("")
+        max_tips = tips.PermanentlyBlockedThreadsTip.MAX_TIPS
+        for i in range(max_tips + 3):
+            javacore_set.threads.snapshot_collections.append(
+                self._make_thread(f"stuck-{i}", f"0x{i}", ["B", "B", "B"])
+            )
+        result = tips.PermanentlyBlockedThreadsTip.generate(javacore_set)
+        self.assertEqual(max_tips, len(result),
+                         f"Should cap output at MAX_TIPS ({max_tips})")


### PR DESCRIPTION
# Summary

Fixes #317

This pull request introduces a new `PermanentlyBlockedThreadsTip` diagnostic that detects threads stuck in a blocked state (`B`) across every javacore snapshot — a strong indicator of a deadlock or permanent starvation. The tip is wired into the existing tips pipeline, surfaced in the AI performance recommendations prompt, and covered by a comprehensive unit test suite.

# Files Changed

📄 `src/javacore_analyser/ai/performance_recommendations_prompter.py`

Adds a new `_get_permanently_blocked_threads()` method that iterates over all thread snapshot collections and identifies threads that are in blocked state (`B`) across every snapshot (subject to the `MIN_SNAPSHOTS` threshold imported from `PermanentlyBlockedThreadsTip`). The result is retrieved and passed as a new `permanently_blocked_threads` variable into the prompt template. A minor blank-line formatting fix is also included.

📄 `src/javacore_analyser/ai/tips_prompter.py`

Extends the tips prompt with an explicit instruction telling the AI to treat any "permanently blocked thread" tip as a potential deadlock or starvation scenario and to recommend investigating the lock that thread is waiting for. Also fixes a missing newline at end of file and corrects the indentation of the `prompt +=` line inside the `for` loop.

📄 `src/javacore_analyser/data/prompts/performance_recommendations_prompt.txt`

Adds a new `Permanently Blocked Threads` section to the prompt template, populated by the `{permanently_blocked_threads}` placeholder. Two new requirement rules are appended: one instructing the AI to flag permanently blocked threads as `HIGH` or `CRITICAL` and recommend lock investigation, and another telling it to stay silent when no such threads are present.

📄 `src/javacore_analyser/tips.py`

Introduces the `PermanentlyBlockedThreadsTip` class. It defines a `MIN_SNAPSHOTS = 3` threshold to avoid false positives on short-lived threads, a `MAX_TIPS = 5` cap to keep output concise, and a `generate()` static method that scans all thread snapshot collections and emits a `[WARNING]` message for each thread blocked in every snapshot. The new tip is also registered in the `TIPS_LIST` at the top of the file.

📄 `test/test_tips.py`

Adds seven unit tests for `PermanentlyBlockedThreadsTip` covering: no threads present, no blocked threads, exactly one permanently blocked thread, a partially blocked thread (should not trigger), threads below the `MIN_SNAPSHOTS` threshold, multiple blocked threads each producing their own warning, and the `MAX_TIPS` cap behaviour. A `_make_thread()` helper method is introduced to reduce boilerplate when constructing `Thread` and `ThreadSnapshot` objects.