### PR TITLE
#322 removed duplicated pandas requirement from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ flask # WSGI server for development the code
 tqdm
 haralyzer
 ollama
-pandas
 markdown
 
 #The requirements below are needed for WatsonX LLM integration


### PR DESCRIPTION
# Summary

Fixes #322

Removes the `pandas` dependency from the project requirements.

# Files Changed

📄 `requirements.txt`

Removes `pandas` from the list of required dependencies. This suggests that `pandas` is either no longer used in the codebase, has been replaced by an alternative library, or its functionality has been removed/refactored.