### PR TITLE
#325 Corrected inconsistencies in config.ini

### DIFF
--- a/src/javacore_analyser/config.ini
+++ b/src/javacore_analyser/config.ini
@@ -22,24 +22,24 @@ reports_dir = reports
 
 [ml]
 # Flag whether to use Machine Learning- based thread classification
-use_ml=False
+use_ml = False
 
 [ai]
 # Flag whether use ai functions
-use_ai=False
+use_ai = False
 # There are three LLM methods: Ollama server, HuggingFace (local, no server required), or WatsonX (remote)
 #llm_method = ollama
 # LLM model to use. For available models see https://ollama.com/library
 #llm = ibm/granite4:latest
-llm_method=huggingface
+llm_method = huggingface
 # List of available models: https://huggingface.co/collections/ibm-granite/granite-40-language-models
-llm=ibm-granite/granite-4.0-micro
+llm = ibm-granite/granite-4.0-micro
 # WatsonX configuration (only needed when llm_method=watsonx)
-#llm_method=watsonx
-#llm=ibm/granite-4-h-small
-#watsonx_api_key=your_api_key_here
-#watsonx_project_id=your_project_id_here
-#watsonx_url=https://us-south.ml.cloud.ibm.com
+#llm_method = watsonx
+#llm = ibm/granite-4-h-small
+#watsonx_api_key = your_api_key_here
+#watsonx_project_id = your_project_id_here
+#watsonx_url = https://us-south.ml.cloud.ibm.com
 
 # Common LLM options
 llm_max_tokens = default


### PR DESCRIPTION
# Summary

Fixes #325

Standardize formatting in the configuration file by adding spacing around assignment operators in the ML and AI sections. This improves readability and keeps configuration entries consistent without changing behavior.

# Files Changed

📄 `src/javacore_analyser/config.ini`

Cleaned up formatting for configuration values in the `[ml]` and `[ai]` sections by adding spaces around `=`. Updated both active and commented configuration examples, including `use_ml`, `use_ai`, `llm_method`, `llm`, and WatsonX-related settings, to use a consistent style.