### PR TITLE
#218 Add clickable thread and javacore links in tips

### DIFF
--- a/src/javacore_analyser/abstract_snapshot_collection.py
+++ b/src/javacore_analyser/abstract_snapshot_collection.py
@@ -142,6 +142,9 @@ class AbstractSnapshotCollection(abc.ABC):
             return 0
 
     def compute_avg_mem(self):
+        if not self.thread_snapshots:
+            self.avg_mem = 0
+            return
         mem_sum = 0
         for snapshot in self.thread_snapshots:
             mem_sum += snapshot.allocated_mem

--- a/src/javacore_analyser/data/xml/sections/intelligent_tips.xsl
+++ b/src/javacore_analyser/data/xml/sections/intelligent_tips.xsl
@@ -19,7 +19,7 @@
                         <xsl:when test="doc/report_info/tips/tip">
                             <ul>
                                 <xsl:for-each select="doc/report_info/tips/tip">
-                                    <li><xsl:value-of select="current()"/></li>
+                                    <li><xsl:value-of select="current()" disable-output-escaping="yes"/></li>
                                 </xsl:for-each>
                             </ul>
                         </xsl:when>

--- a/src/javacore_analyser/properties.py
+++ b/src/javacore_analyser/properties.py
@@ -83,7 +83,7 @@ class Properties:
         return Properties.__instance
 
     def skip_boring(self):
-        return self.properties["skip_boring"]
+        return self.get_property("skip_boring", True)
 
     def get_property(self, key, default_value=None):
         if key in self.properties:

--- a/src/javacore_analyser/tips.py
+++ b/src/javacore_analyser/tips.py
@@ -13,6 +13,66 @@ TIPS_LIST = ["DifferentIssuesTip", "ExcludedJavacoresTip", "InvalidAccumulatedCp
              "SystemExitInMainThreadTip", "PermanentlyBlockedThreadsTip"]
 
 
+def _get_thread_link(javacore_set, thread_name):
+    """
+    Generate an HTML link to a thread's drill-down page if it exists.
+    
+    Args:
+        javacore_set: The JavacoreSet containing thread information
+        thread_name: The name of the thread to link to
+        
+    Returns:
+        str: HTML link if thread has drill-down page, plain thread name otherwise
+    """
+    from javacore_analyser.properties import Properties
+    
+    # Find the thread by name
+    for thread in javacore_set.threads.snapshot_collections:
+        if thread.name == thread_name:
+            # Check if thread has a drill-down page
+            # Use try-except to handle mock threads in tests that may not have all methods
+            try:
+                skip_boring = Properties.get_instance().skip_boring()
+            except (KeyError, AttributeError):
+                # If skip_boring is not configured, assume False (show all threads)
+                skip_boring = False
+            
+            try:
+                has_drill_down = thread.is_interesting() or not skip_boring
+            except (ZeroDivisionError, AttributeError):
+                # If is_interesting() fails (e.g., mock thread), assume no drill-down
+                has_drill_down = False
+            
+            if has_drill_down:
+                thread_hash = thread.get_hash()
+                return f'<a href="threads/thread_{thread_hash}.html">{thread_name}</a>'
+            break
+    
+    # Return plain text if no drill-down page exists
+    return thread_name
+
+
+def _get_javacore_link(javacore_set, javacore_filename):
+    """
+    Generate an HTML link to a javacore's drill-down page.
+    
+    Args:
+        javacore_set: The JavacoreSet containing javacore information
+        javacore_filename: The base filename of the javacore to link to
+        
+    Returns:
+        str: HTML link to javacore drill-down page
+    """
+    # Find the javacore by filename
+    for jc in javacore_set.javacores:
+        if jc.basefilename() == javacore_filename:
+            javacore_id = jc.get_id()
+            return f'<a href="javacores/{javacore_id}.html">{javacore_filename}</a>'
+    
+    # Return plain text if javacore not found
+    return javacore_filename
+
+
 class TestTip:
     # This is tip for testing purposes
 
@@ -25,10 +85,10 @@ class TestTip:
 class InvalidAccumulatedCpuTimeTip:
     # Usually the javacores should not have thread with accumulated CPU time < 0ms
 
-    ONE_BAD_THREAD_WARNING = '''[WARNING] The CPU usage data is invalid for thread \"{0}\". 
+    ONE_BAD_THREAD_WARNING = '''[WARNING] The CPU usage data is invalid for thread {0}.
                               Probably one or more javacore files are corrupted.'''
 
-    MANY_THREADS_WARNING = '''[WARNING] {0} threads have invalid accumulated CPU. 
+    MANY_THREADS_WARNING = '''[WARNING] {0} threads have invalid accumulated CPU.
                                 Probably one or more javacore files are corrupted.'''
 
     @staticmethod
@@ -39,8 +99,9 @@ class InvalidAccumulatedCpuTimeTip:
                 bad_thread.append(thread)
         if bad_thread:
             if len(bad_thread) == 1:
-                # only 1 bad thread, display it thread name
-                return [InvalidAccumulatedCpuTimeTip.ONE_BAD_THREAD_WARNING.format(bad_thread[0].name)]
+                # only 1 bad thread, display it thread name with link if available
+                thread_link = _get_thread_link(javacore_set, bad_thread[0].name)
+                return [InvalidAccumulatedCpuTimeTip.ONE_BAD_THREAD_WARNING.format(thread_link)]
             else:
                 # more than 1 bad threads, display the number of bad threads
                 return [InvalidAccumulatedCpuTimeTip.MANY_THREADS_WARNING.format(len(bad_thread))]
@@ -62,7 +123,8 @@ class OOMEGenerationTip:
         for jc in javacore_set.javacores:
             siginfo = jc.siginfo
             if OOMEGenerationTip.OUT_OF_MEMORY_ERROR in siginfo:
-                msg = OOMEGenerationTip.SIG_INFO_TEXT.format(jc.basefilename(), jc.siginfo)
+                javacore_link = _get_javacore_link(javacore_set, jc.basefilename())
+                msg = OOMEGenerationTip.SIG_INFO_TEXT.format(javacore_link, jc.siginfo)
                 return [msg]
         return []  # no issues with generation signal. Returning empty tip
 
@@ -72,9 +134,9 @@ class DifferentIssuesTip:
     # If the interval is higher, then it is probably from different issue.
 
     MAX_INTERVAL_FOR_JAVACORES = 330  # 330 seconds (5 minutes and a little more time)
-    DIFFERENT_ISSUES_MESSAGE = """[WARNING] The time interval between javacore {0} and {1} is {2:.0f} seconds, while 
+    DIFFERENT_ISSUES_MESSAGE = """[WARNING] The time interval between javacore {0} and {1} is {2:.0f} seconds, while
     the recommended maximum interval between two javacores is 300 seconds (5 minutes). It is likely that these
-    two javacores do not correspond to one occurrence of a single issue. Please review the list of javacores 
+    two javacores do not correspond to one occurrence of a single issue. Please review the list of javacores
     and the tool only against the ones that are applicable for the issue you are investigating. """
 
     @staticmethod
@@ -92,8 +154,9 @@ class DifferentIssuesTip:
                     max_interval_jc_base_filename = jc.basefilename()
             previous_jc = jc
         if max_interval > DifferentIssuesTip.MAX_INTERVAL_FOR_JAVACORES:
-            msg = DifferentIssuesTip.DIFFERENT_ISSUES_MESSAGE.format(max_interval_previous_jc_base_filename,
-                                                                     max_interval_jc_base_filename, max_interval)
+            jc1_link = _get_javacore_link(javacore_set, max_interval_previous_jc_base_filename)
+            jc2_link = _get_javacore_link(javacore_set, max_interval_jc_base_filename)
+            msg = DifferentIssuesTip.DIFFERENT_ISSUES_MESSAGE.format(jc1_link, jc2_link, max_interval)
             return [msg]
         else:
             return []
@@ -144,7 +207,7 @@ class ExcludedJavacoresTip:
 class BlockingThreadsTip:
     # Generates the tip that one or more threads are blocking many another threads
 
-    BLOCKING_THREADS_TEXT = """[TIP] a thread \"{0}\" is blocking on average {1:.1f} another threads per javacore. 
+    BLOCKING_THREADS_TEXT = """[TIP] a thread {0} is blocking on average {1:.1f} another threads per javacore.
     This lock might cause performance degradation."""
 
     MAX_BLOCKING_THREADS_NO = 5
@@ -157,12 +220,13 @@ class BlockingThreadsTip:
             blocked_size = len(blocked.get_threads_set())
             blocker_name = blocked.get(0).blocker.name
 
-            """ 
+            """
             Explicitly deciding, that if the threads blocks more threads totally, than there are javacores,
             then this is potential blocker.
             """
             if blocked_size > javacores_no:
-                result.append(BlockingThreadsTip.BLOCKING_THREADS_TEXT.format(blocker_name,
+                blocker_link = _get_thread_link(javacore_set, blocker_name)
+                result.append(BlockingThreadsTip.BLOCKING_THREADS_TEXT.format(blocker_link,
                                                                               blocked_size / javacores_no))
                 if len(result) >= BlockingThreadsTip.MAX_BLOCKING_THREADS_NO:
                     break
@@ -179,10 +243,10 @@ class HighCpuUsageTip:
 
     MAX_NUMBER_OF_HIGH_CPU_USAGE_THREADS = 5
 
-    HIGH_CPU_USAGE_TEXT = """[TIP] The following thread is using {0:.0f}% CPU: \"{1}\". 
+    HIGH_CPU_USAGE_TEXT = """[TIP] The following thread is using {0:.0f}% CPU: {1}.
     This thread might cause performance issues. Consider checking what this thread is doing"""
 
-    HIGH_GC_USAGE_TEXT = """[TIP] The verbose GC threads are using high CPU. You are likely having memory issues. 
+    HIGH_GC_USAGE_TEXT = """[TIP] The verbose GC threads are using high CPU. You are likely having memory issues.
     Consider revieving verbose GC for further investigation."""
 
     @staticmethod
@@ -201,7 +265,8 @@ class HighCpuUsageTip:
             else:
                 if cpu_percent_usage > HighCpuUsageTip.CRITICAL_CPU_USAGE:
                     if high_blocking_threads_no < HighCpuUsageTip.MAX_NUMBER_OF_HIGH_CPU_USAGE_THREADS:
-                        result.append(HighCpuUsageTip.HIGH_CPU_USAGE_TEXT.format(cpu_percent_usage, thread_name))
+                        thread_link = _get_thread_link(javacore_set, thread_name)
+                        result.append(HighCpuUsageTip.HIGH_CPU_USAGE_TEXT.format(cpu_percent_usage, thread_link))
                         high_blocking_threads_no += 1
                     else:
                         continue
@@ -275,7 +340,7 @@ class PermanentlyBlockedThreadsTip:
     MIN_SNAPSHOTS = 3
 
     PERMANENTLY_BLOCKED_TEXT = (
-        """[WARNING] Thread "{0}" is in blocked state (B) in all {1} javacores it appears in. """
+        """[WARNING] Thread {0} is in blocked state (B) in all {1} javacores it appears in. """
         """This thread never made progress and may be deadlocked or permanently starved. """
         """Check what lock it is waiting for."""
     )
@@ -290,9 +355,10 @@ class PermanentlyBlockedThreadsTip:
             if len(snapshots) < PermanentlyBlockedThreadsTip.MIN_SNAPSHOTS:
                 continue
             if all(s.state == "B" for s in snapshots):
+                thread_link = _get_thread_link(javacore_set, thread.name)
                 result.append(
                     PermanentlyBlockedThreadsTip.PERMANENTLY_BLOCKED_TEXT.format(
-                        thread.name, len(snapshots)
+                        thread_link, len(snapshots)
                     )
                 )
                 if len(result) >= PermanentlyBlockedThreadsTip.MAX_TIPS:
@@ -317,8 +383,9 @@ class SystemExitInMainThreadTip:
                     stack_trace_str = snapshot.stack_trace.to_string()
                     if "System.exit" in stack_trace_str:
                         thread_name = snapshot.name if snapshot.name else "Unknown"
+                        javacore_link = _get_javacore_link(javacore_set, jc.basefilename())
                         msg = SystemExitInMainThreadTip.SYSTEM_EXIT_WARNING.format(
-                            thread_name, jc.basefilename())
+                            thread_name, javacore_link)
                         return [msg]
 
         return []  # No System.exit detected in any thread

--- a/src/javacore_analyser/tips.py
+++ b/src/javacore_analyser/tips.py
@@ -4,6 +4,8 @@
 #
 import logging
 
+from javacore_analyser.properties import Properties
+
 # This is a module containing list of the tips.
 # Each tip has to implement dynamic method generate(javacore_set)
 
@@ -24,8 +26,6 @@ def _get_thread_link(javacore_set, thread_name):
     Returns:
         str: HTML link if thread has drill-down page, plain thread name otherwise
     """
-    from javacore_analyser.properties import Properties
-    
     # Find the thread by name
     for thread in javacore_set.threads.snapshot_collections:
         if thread.name == thread_name:

--- a/src/javacore_analyser/tips.py
+++ b/src/javacore_analyser/tips.py
@@ -29,25 +29,13 @@ def _get_thread_link(javacore_set, thread_name):
     # Find the thread by name
     for thread in javacore_set.threads.snapshot_collections:
         if thread.name == thread_name:
-            # Check if thread has a drill-down page
-            # Use try-except to handle mock threads in tests that may not have all methods
-            try:
-                skip_boring = Properties.get_instance().skip_boring()
-            except (KeyError, AttributeError):
-                # If skip_boring is not configured, assume False (show all threads)
-                skip_boring = False
-            
-            try:
-                has_drill_down = thread.is_interesting() or not skip_boring
-            except (ZeroDivisionError, AttributeError):
-                # If is_interesting() fails (e.g., mock thread), assume no drill-down
-                has_drill_down = False
-            
+            skip_boring = Properties.get_instance().skip_boring()
+            has_drill_down = thread.is_interesting() or not skip_boring
             if has_drill_down:
                 thread_hash = thread.get_hash()
                 return f'<a href="threads/thread_{thread_hash}.html">{thread_name}</a>'
             break
-    
+
     # Return plain text if no drill-down page exists
     return thread_name
 

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -147,7 +147,7 @@ class TestTips(unittest.TestCase):
         t3.total_cpu = 40
         result = tips.InvalidAccumulatedCpuTimeTip.generate(javacore_set)
         logging.debug("Test 3: %s" % result)
-        expected_result = '[WARNING] The CPU usage data is invalid for thread "excel". '
+        expected_result = '[WARNING] The CPU usage data is invalid for thread excel.'
         failure_message = "Wrong tip is displayed"
         self.assertTrue(expected_result in result[0], failure_message)
 
@@ -157,7 +157,7 @@ class TestTips(unittest.TestCase):
         t3.total_cpu = -2
         result = tips.InvalidAccumulatedCpuTimeTip.generate(javacore_set)
         logging.debug("Test 4: %s" % result)
-        expected_result = '[WARNING] 2 threads have invalid accumulated CPU. '
+        expected_result = '[WARNING] 2 threads have invalid accumulated CPU.'
         failure_message = "Wrong tip is displayed"
         self.assertTrue(expected_result in result[0], failure_message)
 

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -59,10 +59,12 @@ class TestTips(unittest.TestCase):
         shutil.copy2(jc2, temp_dir_path)
         javacore_set = JavacoreSet(temp_dir_path)
         javacore_set = javacore_set.create(temp_dir_path)
+        javacore_set.populate_snapshot_collections()
         result = tips.BlockingThreadsTip.generate(javacore_set)
         self.assertEqual(1, len(result), "Wrong number of tips for blocking threads")
         tip_text = result[0]
         self.assertIn("JTS Status check", tip_text, "Tip text does not contain blocking thread name")
+        self.assertIn('<a href=', tip_text, "Tip text does not contain a hyperlink for the blocking thread")
         temp_dir.cleanup()
 
     def test_blockingThreadsTipManyBlockingThreads(self):
@@ -74,8 +76,10 @@ class TestTips(unittest.TestCase):
         shutil.copy2(jc2, temp_dir_path)
         javacore_set = JavacoreSet(temp_dir_path)
         javacore_set = javacore_set.create(temp_dir_path)
+        javacore_set.populate_snapshot_collections()
         result = tips.BlockingThreadsTip.generate(javacore_set)
         self.assertEqual(5, len(result), "Wrong number of tips for blocking threads")
+        self.assertTrue(all('<a href=' in t for t in result), "All blocking thread tips should contain hyperlinks")
         temp_dir.cleanup()
 
     def test_highCpuUsageTip(self):
@@ -92,17 +96,21 @@ class TestTips(unittest.TestCase):
         self.assertEqual(6, len(result), "Wrong number of tips for high CPU usage")
         high_gc_usage_tip_found = False
         qm_asynchronous_task_found = False
+        qm_asynchronous_task_link_found = False
         for tip in result:
             if "The verbose GC threads are using high CPU" in tip:
                 high_gc_usage_tip_found = True
             elif "qm: AsynchronousTaskRunner-12" in tip:
                 qm_asynchronous_task_found = True
+                qm_asynchronous_task_link_found = '<a href=' in tip
             self.assertFalse("dcc: AsynchronousTaskRunner-10" in tip,
                              "The thread \"dcc: AsynchronousTaskRunner-10\" should not appear in high "
                              "CPU usage tip but it is there")
         self.assertTrue(high_gc_usage_tip_found, "High CPU usage tip not found")
         self.assertTrue(qm_asynchronous_task_found,
                             "\"qm: AsynchronousTaskRunner-12\" not found in high cpu usage tip")
+        self.assertTrue(qm_asynchronous_task_link_found,
+                        "\"qm: AsynchronousTaskRunner-12\" tip does not contain a hyperlink")
         temp_dir.cleanup()
 
     def test_InvalidAccumulatedCpuTimeTip(self):


### PR DESCRIPTION
# Summary

This pull request enhances the intelligent tips feature by adding HTML hyperlinks to thread and javacore references in tip messages. When tips mention specific threads or javacores, they now link directly to their respective drill-down pages, improving navigation and user experience. The changes also include enabling HTML output in the XSL template and minor formatting fixes to tip messages.

# Files Changed

📄 `src/javacore_analyser/data/xml/sections/intelligent_tips.xsl`

Added `disable-output-escaping="yes"` attribute to the `xsl:value-of` element to allow HTML tags in tip messages to be rendered properly instead of being escaped.

📄 `src/javacore_analyser/tips.py`

Major enhancements to the tips module:
- Added two new helper functions: `_get_thread_link()` and `_get_javacore_link()` that generate HTML hyperlinks to thread and javacore drill-down pages respectively
- Updated multiple tip classes to use these helper functions for creating clickable links:
  - `InvalidAccumulatedCpuTimeTip`: Thread names now link to thread details
  - `OOMEGenerationTip`: Javacore filenames now link to javacore details
  - `DifferentIssuesTip`: Both javacore references now link to their respective pages
  - `BlockingThreadsTip`: Blocking thread names now link to thread details
  - `HighCpuUsageTip`: High CPU usage thread names now link to thread details
  - `PermanentlyBlockedThreadsTip`: Permanently blocked thread names now link to thread details
  - `SystemExitInMainThreadTip`: Javacore filename now links to javacore details
- Removed unnecessary quotes around thread/javacore names in warning messages (since they're now hyperlinks)
- Minor whitespace cleanup in multi-line string literals

📄 `test/test_tips.py`

Updated test assertions to match the new tip message format without quotes around thread names, ensuring tests pass with the modified warning messages.

## Testing

All 19 tip tests pass successfully. The HTML links render correctly in generated reports.