### PR TITLE
#65 Add search occurrence counter to report search bar

### DIFF
--- a/src/javacore_analyser/data/jquery/search.js
+++ b/src/javacore_analyser/data/jquery/search.js
@@ -25,7 +25,20 @@ $(function() {
     // top offset for the jump (the search bar)
     offsetTop = 50,
     // the current index of the focused element
-    currentIndex = 0;
+    currentIndex = 0,
+    // the counter display element
+    $counter = $("#search-counter");
+
+  /**
+   * Updates the search counter display
+   */
+  function updateCounter() {
+    if ($results && $results.length > 0) {
+      $counter.text((currentIndex + 1) + "/" + $results.length);
+    } else {
+      $counter.text("");
+    }
+  }
 
   /**
    * Jumps to the element matching the currentIndex
@@ -40,6 +53,7 @@ $(function() {
         position = $current.offset().top - offsetTop;
         window.scrollTo(0, position - 100);
       }
+      updateCounter();
     }
   }
 
@@ -111,6 +125,7 @@ $(function() {
             $results = $content.find("mark");
             currentIndex = 0;
             jumpTo();
+            updateCounter();
           }
         });
       }
@@ -133,6 +148,7 @@ $(function() {
   $clearBtn.on("click", function() {
     $content.unmark();
     $input.val("").focus();
+    $counter.text("");
   });
 
   /**

--- a/src/javacore_analyser/data/jquery/search.js
+++ b/src/javacore_analyser/data/jquery/search.js
@@ -1,5 +1,5 @@
 /*
-# Copyright IBM Corp. 2024 - 2024
+# Copyright IBM Corp. 2024 - 2026
 # SPDX-License-Identifier: Apache-2.0
 */
 

--- a/src/javacore_analyser/data/jquery/search.js
+++ b/src/javacore_analyser/data/jquery/search.js
@@ -125,7 +125,6 @@ $(function() {
             $results = $content.find("mark");
             currentIndex = 0;
             jumpTo();
-            updateCounter();
           }
         });
       }

--- a/src/javacore_analyser/data/style.css
+++ b/src/javacore_analyser/data/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright IBM Corp. 2024 - 2025
+Copyright IBM Corp. 2024 - 2026
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/src/javacore_analyser/data/style.css
+++ b/src/javacore_analyser/data/style.css
@@ -165,6 +165,13 @@ td {
   background-color: black;
 }
 
+.search-counter {
+  color: white;
+  margin-left: 10px;
+  font-size: 14px;
+  vertical-align: middle;
+}
+
 .content {
    padding-bottom: 30px
 }

--- a/src/javacore_analyser/data/xml/javacores/javacore.xsl
+++ b/src/javacore_analyser/data/xml/javacores/javacore.xsl
@@ -31,6 +31,7 @@
                     <button data-search="next">Next</button>
                     <button data-search="prev">Prev</button>
                     <button data-search="clear">✖</button>
+                    <span id="search-counter" class="search-counter"></span>
                 </div>
                 <div class="content">
                     <p class="right"><a href="../index.html"> Back to Main page </a></p>

--- a/src/javacore_analyser/data/xml/javacores/javacore.xsl
+++ b/src/javacore_analyser/data/xml/javacores/javacore.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-# Copyright IBM Corp. 2024 - 2025
+# Copyright IBM Corp. 2024 - 2026
 # SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/src/javacore_analyser/data/xml/report.xsl
+++ b/src/javacore_analyser/data/xml/report.xsl
@@ -44,6 +44,7 @@
             <button data-search="next">Next</button>
             <button data-search="prev">Prev</button>
             <button data-search="clear">✖</button>
+            <span id="search-counter" class="search-counter"></span>
         </div>
         <div class="content">
             <h1>Javacore Analyser Report</h1>

--- a/src/javacore_analyser/data/xml/threads/thread.xsl
+++ b/src/javacore_analyser/data/xml/threads/thread.xsl
@@ -32,6 +32,7 @@
                     <button data-search="next">Next</button>
                     <button data-search="prev">Prev</button>
                     <button data-search="clear">✖</button>
+                    <span id="search-counter" class="search-counter"></span>
                 </div>
                 <div class="content">
                     <p class="right"><a href="../index.html"> Back to Main page </a></p>


### PR DESCRIPTION
Fixes #65

## Summary
Added a search occurrence counter to the report search bar that displays the current highlighted occurrence index and total count in "current/total" format (e.g., "1/5", "2/5").

## Changes
- Added counter display element (`<span id="search-counter">`) to search bars in:
  - `src/javacore_analyser/data/xml/report.xsl`
  - `src/javacore_analyser/data/xml/javacores/javacore.xsl`
  - `src/javacore_analyser/data/xml/threads/thread.xsl`
- Enhanced `search.js` with `updateCounter()` function that:
  - Displays "current/total" format
  - Updates on search, Prev/Next navigation, and clear actions
- Added CSS styling for `.search-counter` class with white text and proper spacing
- Updated copyright year to 2026 in all modified files

## How it was tested
- Generated test report using: `python -m javacore_analyser.javacore_analyser_batch test/data/javacores/javacore.20220606.114458.32888.0001.txt test_output`
- Opened generated HTML report in browser
- Verified search counter displays correctly when searching for text
- Verified counter updates when clicking Prev/Next buttons
- Verified counter clears when clearing search