### PR TITLE
#337 Added scikit-learn dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ license = {file = "LICENSE"}
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -48,6 +47,7 @@ dependencies = [
     "idna>=3.15",  # security floor: PYSEC-2026-215
     "numpy",
     "xgboost",
+    "scikit-learn"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Summary

This pull request contains only meta file changes (like configuration files, lock files, build outputs, documentation, etc.) that are automatically generated or don't require detailed description.

Fixes #337

# How the Fix Was Tested

1. Tested with the following steps:
   ```
   pip install -e .
   javacore_analyser_batch --use_ml=True test/data/archives/javacores.zip /tmp/javacore-test-output
   ```