### PR TITLE
#355 config ini missing from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,14 @@ exclude = [
   "/test",
 ]
 
+[tool.hatch.build.targets.sdist.force-include]
+"src/javacore_analyser/config.ini" = "src/javacore_analyser/config.ini"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/javacore_analyser"]
-artifacts = ["src/javacore_analyser/config.ini"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/javacore_analyser/config.ini" = "javacore_analyser/config.ini"
 
 [tool.hatch.version]
 source = "versioningit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/javacore_analyser"]
+artifacts = ["src/javacore_analyser/config.ini"]
 
 [tool.hatch.version]
 source = "versioningit"

--- a/release.sh
+++ b/release.sh
@@ -147,8 +147,8 @@ if should_run 4; then
   echo "Creating temporary venv in $VENV_DIR ..."
   python -m venv "$VENV_DIR"
 
-  echo "Installing $WHL ..."
-  "$VENV_DIR/bin/pip" install --quiet "$WHL"
+  echo "Installing $WHL[full] ..."
+  "$VENV_DIR/bin/pip" install --quiet "$WHL[full]"
 
   echo "Running tests against the installed package ..."
   PYTHONPATH=test "$VENV_DIR/bin/python" -m unittest discover -s test -v

--- a/src/javacore_analyser/properties.py
+++ b/src/javacore_analyser/properties.py
@@ -5,7 +5,6 @@
 import configparser
 import logging
 import os.path
-import shutil
 
 import importlib_resources
 
@@ -93,5 +92,6 @@ class Properties:
 
     @staticmethod
     def _generate_default_config(config_file):
-        with importlib_resources.path("javacore_analyser", "config.ini") as config_ini_resource:
-            shutil.copy2(config_ini_resource, config_file)
+        config_data = importlib_resources.files("javacore_analyser").joinpath("config.ini").read_bytes()
+        with open(config_file, "wb") as f:
+            f.write(config_data)


### PR DESCRIPTION
# Summary

Fixes #355 

This pull request makes two small improvements: updates the release script to install the package with the `[full]` extras when running post-build tests, and refactors the default config file generation in `properties.py` to use a more modern and compatible `importlib_resources` API, removing the dependency on `shutil`.

# Files Changed

📄 `release.sh`

Updates the pip install command in the temporary virtual environment to use `$WHL[full]` instead of `$WHL`, ensuring the package is installed with all optional `[full]` extras when validating the built wheel during the release process.

📄 `src/javacore_analyser/properties.py`

Refactors the `_generate_default_config` method to replace the `importlib_resources.path` context manager and `shutil.copy2` approach with the newer `importlib_resources.files(...).joinpath(...).read_bytes()` API for reading the bundled `config.ini` resource. The file is then written directly using a standard `open` call. This removes the `shutil` import and avoids reliance on the deprecated path-based resource access pattern, improving compatibility with newer versions of `importlib_resources`.