### PR TITLE
#360 Fixed concurrency issues in javacore_analyser.generate_htmls_from_xmls_xsls

### DIFF
--- a/src/javacore_analyser/javacore_set.py
+++ b/src/javacore_analyser/javacore_set.py
@@ -1046,18 +1046,21 @@ class JavacoreSet:
         threads_no = JavacoreSet.get_number_of_parallel_threads()
         logging.info(f"Using {threads_no} threads to generate html files")
 
-        list_files = os.listdir(data_input_dir)
-        progress_bar = tqdm(desc="Generating html files", unit=' file')
+        # Only pass .xsl files to the worker — it skips everything else anyway,
+        # and filtering here gives tqdm an accurate total count.
+        list_files = [f for f in os.listdir(data_input_dir) if f.endswith(".xsl")]
+        logging.info(f"Generating {len(list_files)} html files from {data_input_dir}")
 
         # Generating list of tuples. This is required attribute for p.map function executed few lines below.
-        generate_html_from_xml_xsl_files_params = []
-        for file in list_files:
-            generate_html_from_xml_xsl_files_params.append((file, data_input_dir, output_dir, progress_bar))
+        generate_html_from_xml_xsl_files_params = [(file, data_input_dir, output_dir) for file in list_files]
 
         with Pool(threads_no) as p:
-            p.map(JavacoreSet.generate_html_from_xml_xsl_files, generate_html_from_xml_xsl_files_params)
+            for _ in tqdm(p.imap_unordered(JavacoreSet.generate_html_from_xml_xsl_files,
+                                           generate_html_from_xml_xsl_files_params),
+                          total=len(generate_html_from_xml_xsl_files_params),
+                          desc="Generating html files", unit=' file'):
+                pass
 
-        progress_bar.close()
         logging.info(f"Generated html files in {output_dir}")
 
     # Run with the same number of threads as you have processes but leave one thread for something else.
@@ -1068,7 +1071,7 @@ class JavacoreSet:
     @staticmethod
     def generate_html_from_xml_xsl_files(args):
 
-        collection_file, collection_input_dir, output_dir, progress_bar = args
+        collection_file, collection_input_dir, output_dir = args
 
         if not collection_file.endswith(".xsl"): return
 
@@ -1094,8 +1097,6 @@ class JavacoreSet:
 
         logging.debug("Generating file " + html_file)
         output_doc.write(html_file, pretty_print=True)
-
-        progress_bar.update(1)
 
     @staticmethod
     def create_xml_xsl_for_collection(tmp_dir, xml_xsls_prefix_path, collection, output_file_prefix):


### PR DESCRIPTION
# Summary

Fix progress bar tracking for parallel HTML file generation in `JavacoreSet`.

Fixes #360

# Changes Made

- **Filter XSL files before dispatching work:** `os.listdir()` results are now pre-filtered to only `.xsl` files, giving `tqdm` an accurate `total` count upfront instead of iterating over all directory entries including non-XSL files.
- **Replace `p.map` with `p.imap_unordered` + `tqdm`:** The progress bar is now driven from the main process by wrapping `imap_unordered` in a `tqdm` iterator, eliminating the need to pass the `progress_bar` object into worker processes.
- **Remove `progress_bar` from worker args:** `generate_html_from_xml_xsl_files` no longer receives or calls `progress_bar.update(1)`, decoupling the worker from UI concerns.
- **Remove redundant guard in worker:** The `if not collection_file.endswith(".xsl"): return` early-exit in the worker is now dead code (all files passed in are already `.xsl`), though it remains as a safety check.
- **Add informational log line:** Logs the number of XSL files found and the source directory before processing begins.

# Testing

- All tests have been rerun to confirm no regressions in HTML generation output.
- Manual verification: ran the analyser against a real javacore dump set and confirm the `tqdm` progress bar increments correctly and reaches 100% upon completion.
- Confirmed the total count shown in the progress bar matches the actual number of `.xsl` files processed.

# Additional Notes

The previous implementation passed a shared `progress_bar` object into `Pool.map` worker processes. Since `multiprocessing` workers run in separate processes, the `tqdm` bar updates were happening in forked subprocesses rather than the main process, meaning the displayed progress was unreliable or invisible. The new approach keeps all UI updates in the main process, which is the correct pattern for `tqdm` with `multiprocessing`.